### PR TITLE
Temporary fix for the Spotify embed crashing bug

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -119,6 +119,13 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
+    if 'open.spotify' in message.content.lower():
+        new_message = message.content.translate({ord('`') : None})
+        author = message.author
+
+        await message.delete()
+        await message.channel.send('Spotify link from %s : `%s`' % (author.name, new_message))
+
     if message.content.lower() in MARTY_RESPONSES:
         await message.channel.send(MARTY_RESPONSES[message.content.lower()])
         return

--- a/Main.py
+++ b/Main.py
@@ -120,11 +120,12 @@ async def on_message(message):
         return
 
     if 'open.spotify' in message.content.lower():
-        new_message = message.content.translate({ord('`') : None})
+        new_message = message.content.translate({ord('`'): None})
         author = message.author
 
         await message.delete()
-        await message.channel.send('Spotify link from %s : `%s`' % (author.name, new_message))
+        await message.channel.send(
+            'Spotify link from %s : `%s`' % (author.name, new_message))
 
     if message.content.lower() in MARTY_RESPONSES:
         await message.channel.send(MARTY_RESPONSES[message.content.lower()])


### PR DESCRIPTION
Messages containing the open.spotify.com url are deleted and the original message is reposted in backticks as follows:

Spotify link from <username>: `<original message>`