### PR TITLE
Issue 140, fixes to quoter delete function

### DIFF
--- a/cogs/quotes.py
+++ b/cogs/quotes.py
@@ -114,6 +114,11 @@ class Quotes(commands.Cog):
         await msg.add_reaction('🚮')
 
         def check(reaction, user):
+            # returns True if all the following is true:
+            # The user who reacted is either the quoter or the quoted person
+            # The user who reacted isn't the bot
+            # The react is the delete emoji
+            # The react is on the "Quote added." message
             return (
                 user == ctx.message.author
                 or user == member) and user != self.bot.user and str(

--- a/cogs/quotes.py
+++ b/cogs/quotes.py
@@ -114,8 +114,10 @@ class Quotes(commands.Cog):
         await msg.add_reaction('🚮')
 
         def check(reaction, user):
-            return user == ctx.message.author or user == member and str(
-                reaction.emoji) == '🚮'
+            return (
+                user == ctx.message.author
+                or user == member) and user != self.bot.user and str(
+                    reaction.emoji) == '🚮' and reaction.message.id == msg.id
 
         try:
             await self.bot.wait_for('reaction_add', check=check, timeout=120)


### PR DESCRIPTION
See #140 
The delete react now only works on the "Quote added." message , and it prevents Canary from deleting his own new quotes. Tested with my bot.