### PR TITLE
Embed image URL in quote if it exists

### DIFF
--- a/cogs/quotes.py
+++ b/cogs/quotes.py
@@ -208,6 +208,13 @@ class Quotes(commands.Cog):
         embed = discord.Embed(colour=discord.Colour(random.randint(
             0, 16777215)),
                               description=quote)
+
+        img_regex = r'https?://.*\.(?:jpg|gif|png|jpeg)\S*'
+        img_urls_found = re.findall(img_regex, quote)
+
+        if img_urls_found:
+            embed.set_image(url=img_urls_found[0])
+
         embed.set_author(name=author_name, icon_url=pfp)
         await ctx.send(embed=embed)
 


### PR DESCRIPTION


## Description
Fixing a regression from PR #156. Image regex is conservative for jpg,
gif, png, and jpeg filename suffixes.

## Motivation and Context
Resolves: Issue #164 

## How Has This Been Tested?
Tested in test server for correct embedding and against false positives.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

