### PR TITLE
Close Issue 166

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -96,9 +96,10 @@ class Helpers(commands.Cog):
                     except Exception:
                         img_url = ""
                         summary = recall['summary']
-                    recall_warning.set_image(url=img_url)
-                    recall_warning.add_field(name="Summary", value=summary)
-                    await recall_channel.send(embed=recall_warning)
+                    if re.search(r'Quebec|National', summary, re.IGNORECASE):
+                        recall_warning.set_image(url=img_url)
+                        recall_warning.add_field(name="Summary", value=summary)
+                        await recall_channel.send(embed=recall_warning)
             if new_recalls:
                 # Pickle newly added IDs
                 id_pickle = open("pickles/recall_tag.obj", 'wb')


### PR DESCRIPTION
Parse food warnings for location

## Description

Only send food warnings if for Quebec or national with the use of regexes.

## Motivation and Context

Resolves: Issue #166

## How Has This Been Tested?
Tested in test server mimicking actual server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

