### PR TITLE
Add "Quote not found" message deletion option

### DIFF
--- a/cogs/quotes.py
+++ b/cogs/quotes.py
@@ -190,8 +190,31 @@ class Quotes(commands.Cog):
                 quotes = c.fetchall()
 
         if not quotes:
+            msg = await ctx.send('Quote not found.\n')
+            await msg.add_reaction('🆗')
+
+            def check(reaction, user):
+                # returns True if all the following is true:
+                # The user who reacted isn't the bot
+                # The react is the ok emoji
+                # The react is on the "Quote not found." message
+                return (user == ctx.message.author and user != self.bot.user
+                        ) and (str(reaction.emoji) == '🆗'
+                               and reaction.message.id == msg.id)
+
+            try:
+                await self.bot.wait_for('reaction_add',
+                                        check=check,
+                                        timeout=120)
+
+            except asyncio.TimeoutError:
+                await msg.remove_reaction('🆗', self.bot.user)
+
+            else:
+                await ctx.message.delete()
+                await msg.delete()
+
             conn.close()
-            await ctx.send('Quote not found.')
             return
 
         conn.close()


### PR DESCRIPTION
## Description
Implementation of feature to allow user making quote query to delete the 'quote not found' bot message along with the query message itself

## Motivation and Context
Motivated by Issue #163 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

