### PR TITLE
Issue 183

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -575,7 +575,7 @@ class Helpers(commands.Cog):
         img[:, :] = (b, g, r)
         ext = "jpg"
         retval, buffer = cv2.imencode('.{}'.format(ext), img,
-                                      [cv2.IMWRITE_JPEG_QUALITY, 100])
+                                      [cv2.IMWRITE_JPEG_QUALITY, 0])
         buffer = BytesIO(buffer)
         fn = "{}.{}".format(match.group(1), ext)
         await ctx.send(file=discord.File(fp=buffer, filename=fn))

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -555,6 +555,31 @@ class Helpers(commands.Cog):
         embed = discord.Embed(colour=0xDA291C, description=msg)
         await ctx.send(embed=embed)
 
+    @commands.command(aliases=["color"])
+    async def colour(self, ctx, *, arg: str):
+        """Shows a small image filled with the given hex colour.
+        Usage: `?colour hex`
+        """
+        allowed = re.compile("^#?(?:0x)?([0-9a-fA-F]{6})$")
+        match = allowed.match(arg)
+        if not match:
+            await ctx.send("Please use a valid 6-digit hex number.")
+            return
+        await ctx.trigger_typing()
+        c = int(match.group(1), 16)
+        r = (c & 0xFF0000) >> 16
+        g = (c & 0xFF00) >> 8
+        b = c & 0xFF
+        SIZE = 64
+        img = np.zeros((SIZE, SIZE, 3), np.uint8)
+        img[:, :] = (b, g, r)
+        ext = "jpg"
+        retval, buffer = cv2.imencode('.{}'.format(ext), img,
+                                      [cv2.IMWRITE_JPEG_QUALITY, 100])
+        buffer = BytesIO(buffer)
+        fn = "{}.{}".format(match.group(1), ext)
+        await ctx.send(file=discord.File(fp=buffer, filename=fn))
+
 
 def setup(bot):
     bot.add_cog(Helpers(bot))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
Adds a `colour` (aliased to `color`) command that will reply to a hex colour code with a small square of that colour.

Usage: `colour #?(0x)?[0-9a-fA-F]{6}`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #183 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on test server.


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2417212/67994323-033a9c00-fc1b-11e9-984a-ec1741ec76b5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

