### PR TITLE
fix utf8 support; add greek support in text and math for unicode; use…

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -371,10 +371,15 @@ class Helpers(commands.Cog):
             tex += "\\[" + sp[2 * i + 1] + "\\]"
 
         buf = BytesIO()
+        LATEX_PREAMBLE = ("\\documentclass[varwidth,12pt]{standalone}"
+                   "\\usepackage{alphabeta}"
+                   "\\usepackage[utf8]{inputenc}"
+                   "\\usepackage[LGR,T1]{fontenc}"
+                   "\\usepackage{amsmath,amsfonts,lmodern}"
+                   "\\begin{document}")
         preview(
             tex,
-            preamble=
-            "\\documentclass[varwidth,12pt]{standalone}\\usepackage{alphabeta}\\usepackage[utf8]{inputenc}\\usepackage[LGR,T1]{fontenc}\\usepackage{amsmath,amsfonts,lmodern}\\begin{document}",
+            preamble=LATEX_PREAMBLE,
             viewer="BytesIO",
             outputbuffer=buf,
             euler=False,

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -373,7 +373,8 @@ class Helpers(commands.Cog):
         buf = BytesIO()
         preview(
             tex,
-            preamble="\\documentclass[varwidth,12pt]{standalone}\\usepackage{alphabeta}\\usepackage[utf8]{inputenc}\\usepackage[LGR,T1]{fontenc}\\usepackage{amsmath,amsfonts,lmodern}\\begin{document}",
+            preamble=
+            "\\documentclass[varwidth,12pt]{standalone}\\usepackage{alphabeta}\\usepackage[utf8]{inputenc}\\usepackage[LGR,T1]{fontenc}\\usepackage{amsmath,amsfonts,lmodern}\\begin{document}",
             viewer="BytesIO",
             outputbuffer=buf,
             euler=False,

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -373,6 +373,7 @@ class Helpers(commands.Cog):
         buf = BytesIO()
         preview(
             tex,
+            preamble="\\documentclass[varwidth,12pt]{standalone}\\usepackage{alphabeta}\\usepackage[utf8]{inputenc}\\usepackage[LGR,T1]{fontenc}\\usepackage{amsmath,amsfonts,lmodern}\\begin{document}",
             viewer="BytesIO",
             outputbuffer=buf,
             euler=False,

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -372,11 +372,11 @@ class Helpers(commands.Cog):
 
         buf = BytesIO()
         LATEX_PREAMBLE = ("\\documentclass[varwidth,12pt]{standalone}"
-                   "\\usepackage{alphabeta}"
-                   "\\usepackage[utf8]{inputenc}"
-                   "\\usepackage[LGR,T1]{fontenc}"
-                   "\\usepackage{amsmath,amsfonts,lmodern}"
-                   "\\begin{document}")
+                          "\\usepackage{alphabeta}"
+                          "\\usepackage[utf8]{inputenc}"
+                          "\\usepackage[LGR,T1]{fontenc}"
+                          "\\usepackage{amsmath,amsfonts,lmodern}"
+                          "\\begin{document}")
         preview(
             tex,
             preamble=LATEX_PREAMBLE,


### PR DESCRIPTION
… latin modern for improved font support in tex

<!--- Provide a general summary of your changes in the title -->

## Description
LaTeX now loads `alphabeta` for Greek support, `inputenc` for Unicode support, `LGR` and `T1` encodings for a wider character set and `lmodern` for improved font support (adopted in modern TeX engines), alongside the existing options.

## Motivation and Context
Fixes https://github.com/idoneam/Canary/issues/203, and also improves TeX support.

## How Has This Been Tested?
Tested in test server and everything is good

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

