### PR TITLE
[fix][subscribers] Remove incorrect dir creation

### DIFF
--- a/cogs/subscribers.py
+++ b/cogs/subscribers.py
@@ -45,7 +45,7 @@ metro_status = {
     "5": ["Normal métro service", 33738]
 }    # Blue Line
 
-os.mkdir('./pickles', exist_ok=True)
+os.makedirs('./pickles', exist_ok=True)
 
 
 class Subscribers(commands.Cog):


### PR DESCRIPTION
**Why this change was necessary**

An incorrect function call was causing the cog to not be loaded,
meaning the CFIA recalls and metro status warnings were not
functioning. The arguments to the erroneous call were for a different,
intended call.

**What this change does**
See diff.

**Any side-effects?**
None noticed.

**Additional context/notes/links**

Resolves #217

<!--- Provide a general summary of your changes in the title -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

