### PR TITLE
[fix][subscribers] Regenerate metro status dict

### DIFF
--- a/cogs/subscribers.py
+++ b/cogs/subscribers.py
@@ -36,14 +36,27 @@ import requests
 CFIA_FEED_URL = "http://inspection.gc.ca/eng/1388422350443/1388422374046.xml"
 METRO_STATUS_API = "https://www.stm.info/en/ajax/etats-du-service"
 
+METRO_GREEN_LINE = "1"
+METRO_ORANGE_LINE = "2"
+METRO_YELLOW_LINE = "4"
+METRO_BLUE_LINE = "5"
+
+METRO_COLOURS = {
+    METRO_GREEN_LINE: 0x008E4F,
+    METRO_ORANGE_LINE: 0xF08123,
+    METRO_YELLOW_LINE: 0xFFE400,
+    METRO_BLUE_LINE: 0x0083CA,
+}
+
+METRO_NORMAL_SERVICE_MESSAGE = "Normal métro service"
+
 # Default values by line number for status
-# Integers in list are line colours
 metro_status = {
-    "1": ["Normal métro service", 36431],    # Green Line
-    "2": ["Normal métro service", 15761699],    # Orange Line
-    "4": ["Normal métro service", 16770048],    # Yellow Line
-    "5": ["Normal métro service", 33738]
-}    # Blue Line
+    METRO_GREEN_LINE: METRO_NORMAL_SERVICE_MESSAGE,
+    METRO_ORANGE_LINE: METRO_NORMAL_SERVICE_MESSAGE,
+    METRO_YELLOW_LINE: METRO_NORMAL_SERVICE_MESSAGE,
+    METRO_BLUE_LINE: METRO_NORMAL_SERVICE_MESSAGE,
+}
 
 os.makedirs('./pickles', exist_ok=True)
 
@@ -122,11 +135,11 @@ class Subscribers(commands.Cog):
             response = requests.request("GET", METRO_STATUS_API)
             for line_status in metro_status.items():
                 line_number = line_status[0]
-                cached_status = line_status[1][0]
-                line_colour = line_status[1][1]
+                cached_status = line_status[1]
+                line_colour = METRO_COLOURS[line_number]
                 current_status = check_status(line_number, response)
                 if current_status[1] != cached_status:
-                    metro_status[line_number] = current_status
+                    metro_status[line_number] = current_status[1]
                     metro_status_update = discord.Embed(
                         title=current_status[0],
                         description=current_status[1],

--- a/cogs/subscribers.py
+++ b/cogs/subscribers.py
@@ -132,18 +132,17 @@ class Subscribers(commands.Cog):
             metro_status_channel = utils.get(
                 self.bot.get_guild(self.bot.config.server_id).text_channels,
                 name=self.bot.config.metro_status_channel)
-            response = requests.request("GET", METRO_STATUS_API)
+            response = requests.get(METRO_STATUS_API)
             for line_status in metro_status.items():
                 line_number = line_status[0]
                 cached_status = line_status[1]
-                line_colour = METRO_COLOURS[line_number]
-                current_status = check_status(line_number, response)
-                if current_status[1] != cached_status:
-                    metro_status[line_number] = current_status[1]
+                line_name, current_status = check_status(line_number, response)
+                if current_status != cached_status:
+                    metro_status[line_number] = current_status
                     metro_status_update = discord.Embed(
-                        title=current_status[0],
-                        description=current_status[1],
-                        colour=line_colour)
+                        title=line_name,
+                        description=current_status,
+                        colour=METRO_COLOURS[line_number])
                     await metro_status_channel.send(embed=metro_status_update)
             await asyncio.sleep(60)    # Run every 60 seconds
 


### PR DESCRIPTION
**Why this change was necessary**
The metro status dictionary was not being regenerated correctly,
leading to type errors. There was also an incorrect comparison being
made in the logical conditions that would trigger a status update
being sent and saved.

**What this change does**
Refactors globals for default status messages and metro
colours. Refactors metro status dict and fixes conditional comparison
for triggering a status being posted in the server and updated in the dict.

**Any side-effects?**
None.

**Additional context/notes/links**
Note that this could not be adequately tested as metro outages are
infrequent.

Thanks to @davidlougheed for the refactor work.

Resolves: #221 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

