### PR TITLE
[fix][subscribers] Filter out interim metro statuses

### DIFF
--- a/cogs/subscribers.py
+++ b/cogs/subscribers.py
@@ -48,6 +48,8 @@ METRO_COLOURS = {
     METRO_BLUE_LINE: 0x0083CA,
 }
 
+METRO_INTERIM_STATUS = "No information"
+
 METRO_NORMAL_SERVICE_MESSAGE = "Normal métro service"
 
 # Default values by line number for status
@@ -137,7 +139,8 @@ class Subscribers(commands.Cog):
                 line_number = line_status[0]
                 cached_status = line_status[1]
                 line_name, current_status = check_status(line_number, response)
-                if current_status != cached_status:
+                if (current_status != cached_status
+                        and current_status != METRO_INTERIM_STATUS):
                     metro_status[line_number] = current_status
                     metro_status_update = discord.Embed(
                         title=line_name,


### PR DESCRIPTION
**Why this change was necessary**
The bot would sometimes output status updates that are interim
statuses in the API, with the message "No information".

**What this change does**
This changes prevents the bot from caching or sending "No information"
statuses.

**Any side-effects?**
None observed.

**Additional context/notes/links**

Resolves #231 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

