### PR TITLE
Improve boot meme

### DIFF
--- a/cogs/memes.py
+++ b/cogs/memes.py
@@ -154,7 +154,6 @@ class Memes(commands.Cog):
     async def boot(self, ctx, num: int = 2, emoji: str = "👢"):
         """Draws a pyramid of boots (or any other emoji), default is 2 unless user specifies
         an integer number of levels of boots."""
-        
         def booty(n, m):
             return "{spaces}{boots}".format(spaces=" " * ((m - n) * 3),
                                             boots=(emoji + " ") * n)

--- a/cogs/memes.py
+++ b/cogs/memes.py
@@ -150,22 +150,22 @@ class Memes(commands.Cog):
         await ctx.send(msg)
         await ctx.message.delete()
 
-    @commands.command()
-    async def boot(self, ctx, num: int = 2, emoji: str = "👢"):
-        """Draws a pyramid of boots (or any other emoji), default is 2 unless user specifies
-        an integer number of levels of boots."""
-        def booty(n, m):
-            return "{spaces}{boots}".format(spaces=" " * ((m - n) * 3),
-                                            boots=(emoji + " ") * n)
+    @commands.command(aliases=['boot'])
+    async def pyramid(self, ctx, num: int = 2, emoji: str = "👢"):
+        """Draws a pyramid of boots, default is 2 unless user specifies an integer number of levels of boots between -8 and 8. Also accepts any other emoji, word or multiword (in quotes) string."""
+        def pyramidy(n, m):
+            return "{spaces}{emojis}".format(spaces=" " * ((m - n) * 3),
+                                             emojis=(emoji + " ") * n)
 
         if (num > 0):
             num = max(min(num, 8), 1)    # Above 8, herre gets angry
-            msg = "\n".join(booty(ln, num) for ln in range(1, num + 1))
+            msg = "\n".join(pyramidy(ln, num) for ln in range(1, num + 1))
         else:
             num = min(max(num, -8), -1)    # Below -8, herre gets angry
             msg = "\n".join(
-                booty(ln, abs(num)) for ln in reversed(range(1,
-                                                             abs(num) + 1)))
+                pyramidy(ln, abs(num))
+                for ln in reversed(range(1,
+                                         abs(num) + 1)))
 
         await ctx.send("**\n{}**".format(msg))
 

--- a/cogs/memes.py
+++ b/cogs/memes.py
@@ -151,17 +151,23 @@ class Memes(commands.Cog):
         await ctx.message.delete()
 
     @commands.command()
-    async def boot(self, ctx, num: int = 2):
-        """Draws a pyramid of boots, default is 3 unless user specifies
+    async def boot(self, ctx, num: int = 2, emoji: str = "👢"):
+        """Draws a pyramid of boots (or any other emoji), default is 2 unless user specifies
         an integer number of levels of boots."""
-
-        num = max(min(num, 8), 1)    # Above 8, herre gets angry
-
+        
         def booty(n, m):
             return "{spaces}{boots}".format(spaces=" " * ((m - n) * 3),
-                                            boots="👢 " * n)
+                                            boots=(emoji + " ") * n)
 
-        msg = "\n".join(booty(ln, num) for ln in range(1, num + 1))
+        if (num > 0):
+            num = max(min(num, 8), 1)    # Above 8, herre gets angry
+            msg = "\n".join(booty(ln, num) for ln in range(1, num + 1))
+        else:
+            num = min(max(num, -8), -1)    # Below -8, herre gets angry
+            msg = "\n".join(
+                booty(ln, abs(num)) for ln in reversed(range(1,
+                                                             abs(num) + 1)))
+
         await ctx.send("**\n{}**".format(msg))
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
<!--- Describe your changes in detail -->

Closes #180 

- Added negative boot values to do inverted triangles
- Added a second parameter to replace boot with anohter character or string.
- Rounds inputs to be in range of -8 and 8

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

@lamminade asked for it. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested with various strings and values. Alignment gets a little wonky with some inputs. There's room to improve the spacing to be more intelligent depending on the length of the input but that's beyond the scope of this PR.

## Screenshots (if appropriate):

Support for negative boots: 
<img width="338" alt="image" src="https://user-images.githubusercontent.com/2529120/71547282-5b5ff700-295b-11ea-81d7-806eb1046cbb.png">


Support for strings
<img width="317" alt="image" src="https://user-images.githubusercontent.com/2529120/71547278-4daa7180-295b-11ea-9dd1-c3fa0e76a5af.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

