### PR TITLE
Issue 271 Added a DnD-style diceroll command

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -43,6 +43,7 @@ startup = [
     "cogs.reminder",
     "cogs.score",
     "cogs.subscribers",
+    "cogs.games",
 ]
 
 # TODO: SHOULD BE DB

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -76,7 +76,7 @@ class Games(commands.Cog):
         # Now that we have our rolls, prep the embed:
         resultsmsg = discord.Embed(
             description='Rolling {} {}-sided dice'
-            ', with a {} modifier'.format(repeat, sides, mod) + mod_desc,
+            ', with a {} modifier{}'.format(repeat, sides, mod, mod_desc),
             colour=0x822AE0)
         if repeat <= 10:    # Anything more and the roll list is too long
             resultsmsg.add_field(name='Rolls',

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -18,6 +18,7 @@
 # along with Canary. If not, see <https://www.gnu.org/licenses/>.
 
 # discord-py requirements
+import discord
 from discord.ext import commands
 
 # Other utilities
@@ -36,10 +37,13 @@ class Games(commands.Cog):
         Supports modifiers, multiple rolls, any-sided dice
         """
         if arg == 'help' or arg == 'h':
-            await ctx.send('Usage: `[r]d[s][+m]`\n'
-                           'Rolls an [s]-sided die [r] times, '
-                           'with modifier [+-m].\n'
-                           'Rolls one 20-sided die by default')
+            helpmsg = discord.Embed(title='DnD Dice Roller Help',
+                                    description='Usage: `[r]d[s][+m]`\n'
+                                                'Rolls an [s]-sided die [r] '
+                                                'times, with modifier [+-m].\n'
+                                                'Rolls one 20-sided die by default',
+                                    colour=0x822AE0)
+            await ctx.send(embed=helpmsg)
         else:
             await ctx.send(random.randint(1,20))
         

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -49,41 +49,34 @@ class Games(commands.Cog):
            roll 5d+3 each   rolls 5 20-sided dice, adding 3 to each roll
         """
         roll_cmd = ROLL_PATTERN.match(arg)
-        params = {
-            'sides': 20,    # Default parameters
-            'repeat': 1,
-            'mod': 0
-        }
         if arg == 'safe':    # nice meme bro
             await ctx.send('https://i.imgur.com/2icUGpc.png')
             return
         # Applying some bounds on parameters
-        params['repeat'] = clamp_default(roll_cmd.group(1), 1, 10000, 1)
-        params['sides'] = clamp_default(roll_cmd.group(2), 1, 100, 20)
-        params['mod'] = clamp_default(roll_cmd.group(3), -100, 100, 0)
+        repeat = clamp_default(roll_cmd.group(1), 1, 10000, 1)
+        sides = clamp_default(roll_cmd.group(2), 1, 100, 20)
+        mod = clamp_default(roll_cmd.group(3), -100, 100, 0)
 
         if mpr == 'each':
-            roll_list, total, maximum, minimum = dnd_roll(params['sides'],
-                                                          params['repeat'],
-                                                          params['mod'],
+            roll_list, total, maximum, minimum = dnd_roll(sides,
+                                                          repeat,
+                                                          mod,
                                                           mpr=True)
             mod_desc = ' to each roll'
         else:
             roll_list, total, maximum, minimum = dnd_roll(
-                params['sides'], params['repeat'], params['mod'])
+                sides, repeat, mod)
             mod_desc = ' to the sum of rolls'
         # Now that we have our rolls, prep the embed:
         resultsmsg = discord.Embed(
             description='Rolling {} {}-sided dice'
-            ', with a {} modifier'.format(params['repeat'], params['sides'],
-                                          params['mod']) + mod_desc,
+            ', with a {} modifier'.format(repeat, sides, mod) + mod_desc,
             colour=0x822AE0)
-        if params[
-                'repeat'] <= 10:  # Anything more and the roll list is too long
+        if repeat <= 10:  # Anything more and the roll list is too long
             resultsmsg.add_field(name='Rolls',
                                  value=str(roll_list)[1:-1],
                                  inline=False)
-        if params['repeat'] > 1:
+        if repeat > 1:
             resultsmsg.add_field(name='Sum', value=total)
             resultsmsg.add_field(name='Minimum', value=minimum)
             resultsmsg.add_field(name='Maximum', value=maximum)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -74,10 +74,10 @@ class Games(commands.Cog):
             roll_list, total, maximum, minimum = dice_roll(sides, repeat, mod)
             mod_desc = ' to the sum of rolls'
         # Now that we have our rolls, prep the embed:
-        resultsmsg = discord.Embed(
-            description='Rolling {} {}-sided dice'
-            ', with a {} modifier{}'.format(repeat, sides, mod, mod_desc),
-            colour=0x822AE0)
+        resultsmsg = discord.Embed(description='Rolling {} {}-sided dice'
+                                   ', with a {} modifier{}'.format(
+                                       repeat, sides, mod, mod_desc),
+                                   colour=0x822AE0)
         if repeat <= 10:    # Anything more and the roll list is too long
             resultsmsg.add_field(name='Rolls',
                                  value=str(roll_list)[1:-1],

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -22,7 +22,6 @@ import discord
 from discord.ext import commands
 
 # Other utilities
-import random
 import re
 from .utils.dnd_roll import dnd_roll
 

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -23,7 +23,7 @@ from discord.ext import commands
 
 # Other utilities
 import re
-from .utils.dnd_roll import dnd_roll
+from .utils.dice_roll import dice_roll
 from .utils.clamp_default import clamp_default
 
 ROLL_PATTERN = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
@@ -64,13 +64,13 @@ class Games(commands.Cog):
             mod = 0
 
         if mpr == 'each':
-            roll_list, total, maximum, minimum = dnd_roll(sides,
+            roll_list, total, maximum, minimum = dice_roll(sides,
                                                           repeat,
                                                           mod,
                                                           mpr=True)
             mod_desc = ' to each roll'
         else:
-            roll_list, total, maximum, minimum = dnd_roll(
+            roll_list, total, maximum, minimum = dice_roll(
                 sides, repeat, mod)
             mod_desc = ' to the sum of rolls'
         # Now that we have our rolls, prep the embed:

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -69,10 +69,12 @@ class Games(commands.Cog):
                                                     params['sides'],
                                                     params['mod']),
                                    colour=0x822AE0)
-        resultsmsg.add_field(name='Rolls', value=str(roll_list)[1:-1], inline=False)
-        resultsmsg.add_field(name='Sum', value=total)
-        resultsmsg.add_field(name='Minimum', value=minimum)
-        resultsmsg.add_field(name='Maximum', value=maximum)
+        if params['repeat'] <= 10: # Anything more and the roll list is too long
+            resultsmsg.add_field(name='Rolls', value=str(roll_list)[1:-1], inline=False)
+        if params['repeat'] > 1:
+            resultsmsg.add_field(name='Sum', value=total)
+            resultsmsg.add_field(name='Minimum', value=minimum)
+            resultsmsg.add_field(name='Maximum', value=maximum)
         await ctx.send(embed=resultsmsg)
 
     

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -25,6 +25,7 @@ from discord.ext import commands
 import re
 from .utils.dnd_roll import dnd_roll
 
+ROLL_PATTERN = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
 
 class Games(commands.Cog):
     def __init__(self, bot):
@@ -46,8 +47,7 @@ class Games(commands.Cog):
            roll 5d12-4      rolls 5 12-sided dice, subtracting 4 from the total
            roll 5d+3 each   rolls 5 20-sided dice, adding 3 to each roll
         """
-        roll_pattern = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
-        roll_cmd = roll_pattern.match(arg)
+        roll_cmd = ROLL_PATTERN.match(arg)
         params = {
             'sides': 20,    # Default parameters
             'repeat': 1,

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -32,7 +32,7 @@ class Games(commands.Cog):
         self.bot = bot
     
     @commands.command()
-    async def roll(self, ctx, arg: str = ''):
+    async def roll(self, ctx, arg: str = '', mpr: str =''):
         """
         Performs a DnD-style diceroll
         Supports modifiers, multiple rolls, any-sided dice
@@ -59,15 +59,24 @@ class Games(commands.Cog):
             if roll_cmd.group(3) != '':
                 params['mod'] = min(max(-100,int(roll_cmd.group(3))), 100)
                 
-        roll_list, total, maximum, minimum = dnd_roll(params['sides'],
+        if mpr == 'each':
+            roll_list, total, maximum, minimum = dnd_roll(params['sides'],
+                                                      params['repeat'],
+                                                      params['mod'],
+                                                      mpr=True)
+            mod_desc = ' to each roll'
+        else:
+            roll_list, total, maximum, minimum = dnd_roll(params['sides'],
                                                       params['repeat'],
                                                       params['mod'])
+            mod_desc = ' to the sum of rolls'
         # Now that we have our rolls, prep the embed:
         resultsmsg = discord.Embed(description='Rolling {} {}-sided dice'
                                                ', with a {} modifier'.format(
                                                     params['repeat'],
                                                     params['sides'],
-                                                    params['mod']),
+                                                    params['mod'])
+                                               +mod_desc,
                                    colour=0x822AE0)
         if params['repeat'] <= 10: # Anything more and the roll list is too long
             resultsmsg.add_field(name='Rolls', value=str(roll_list)[1:-1], inline=False)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -50,7 +50,8 @@ class Games(commands.Cog):
         """
         roll_cmd = ROLL_PATTERN.match(arg)
         if arg == 'safe':    # nice meme bro
-            await ctx.send('https://i.imgur.com/2icUGpc.png')
+            await ctx.send('https://media.giphy.com/media/'
+                           'd3mlE7uhX8KFgEmY/giphy.gif')
             return
         # Applying some bounds on parameters
         if roll_cmd is not None:

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) idoneam (2016-2019)
+#
+# This file is part of Canary
+#
+# Canary is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Canary is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Canary. If not, see <https://www.gnu.org/licenses/>.
+
+# discord-py requirements
+from discord.ext import commands
+
+# Other utilities
+import random
+import re
+from .utils.auto_incorrect import auto_incorrect
+
+
+class Games(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+    
+def setup(bot):
+    bot.add_cog(Games(bot))

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -47,11 +47,19 @@ class Games(commands.Cog):
             return
         if arg == 'help' or arg == 'h':
             helpmsg = discord.Embed(title='DnD Dice Roller Help',
-                                    description='Usage: `[r]d[s][+m]`\n'
-                                                'Rolls an [s]-sided die [r] '
-                                                'times, with modifier [+-m].\n'
+                                    description='Usage: `[r]d[s][+m] [\'each\']`\n'
+                                                'Rolls an `s`-sided die `r` '
+                                                'times, with modifier `+-m`.\n'
+                                                'If `each` is specified, the '
+                                                'modifier is applied to each roll.\n'
                                                 'Rolls one 20-sided die by default',
                                     colour=0x822AE0)
+            helpmsg.add_field(name='Examples',
+                              value='`d6` roll one 6-sided die\n'
+                                    '`3d` rolls 3 20-sided dice\n'
+                                    '`5d12-4` rolls 5 12-sided dice, subtracting 4 from the total\n'
+                                    '`5d+3 each` rolls 5 20-sided dice, adding 3 to each roll',
+                              inline=False)
             await ctx.send(embed=helpmsg)
             return
         elif roll_cmd != None: # Applying some bounds on parameters

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -53,9 +53,14 @@ class Games(commands.Cog):
             await ctx.send('https://i.imgur.com/2icUGpc.png')
             return
         # Applying some bounds on parameters
-        repeat = clamp_default(roll_cmd.group(1), 1, 10000, 1)
-        sides = clamp_default(roll_cmd.group(2), 1, 100, 20)
-        mod = clamp_default(roll_cmd.group(3), -100, 100, 0)
+        if roll_cmd is not None:
+            repeat = clamp_default(roll_cmd.group(1), 1, 10000, 1)
+            sides = clamp_default(roll_cmd.group(2), 1, 100, 20)
+            mod = clamp_default(roll_cmd.group(3), -100, 100, 0)
+        else: # Necessary for empty roll commands - regex won't even match
+            repeat = 1
+            sides = 20
+            mod = 0
 
         if mpr == 'each':
             roll_list, total, maximum, minimum = dnd_roll(sides,

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -23,12 +23,27 @@ from discord.ext import commands
 # Other utilities
 import random
 import re
-from .utils.auto_incorrect import auto_incorrect
 
 
 class Games(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
     
+    @commands.command()
+    async def roll(self, ctx, arg: str = None):
+        """
+        Performs a DnD-style diceroll
+        Supports modifiers, multiple rolls, any-sided dice
+        """
+        if arg == 'help' or arg == 'h':
+            await ctx.send('Usage: `[r]d[s][+m]`\n'
+                           'Rolls an [s]-sided die [r] times, '
+                           'with modifier [+-m].\n'
+                           'Rolls one 20-sided die by default')
+        else:
+            await ctx.send(random.randint(1,20))
+        
+    
 def setup(bot):
     bot.add_cog(Games(bot))
+    

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -24,6 +24,7 @@ from discord.ext import commands
 # Other utilities
 import re
 from .utils.dnd_roll import dnd_roll
+from .utils.clamp_default import clamp_default
 
 ROLL_PATTERN = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
 
@@ -42,7 +43,7 @@ class Games(commands.Cog):
                                 Defaults to rolling one 20-sided die.
           Examples:
            roll             rolls a d20
-           roll d6          roll one 6-sided die
+           roll d6          rolls one 6-sided die
            roll 3d          rolls 3 20-sided dice
            roll 5d12-4      rolls 5 12-sided dice, subtracting 4 from the total
            roll 5d+3 each   rolls 5 20-sided dice, adding 3 to each roll
@@ -56,13 +57,10 @@ class Games(commands.Cog):
         if arg == 'safe':    # nice meme bro
             await ctx.send('https://i.imgur.com/2icUGpc.png')
             return
-        elif roll_cmd != None:    # Applying some bounds on parameters
-            if roll_cmd.group(1) != '':
-                params['repeat'] = min(max(1, int(roll_cmd.group(1))), 10000)
-            if roll_cmd.group(2) != '':
-                params['sides'] = min(max(1, int(roll_cmd.group(2))), 100)
-            if roll_cmd.group(3) != '':
-                params['mod'] = min(max(-100, int(roll_cmd.group(3))), 100)
+        # Applying some bounds on parameters
+        params['repeat'] = clamp_default(roll_cmd.group(1), 1, 10000, 1)
+        params['sides'] = clamp_default(roll_cmd.group(2), 1, 100, 20)
+        params['mod'] = clamp_default(roll_cmd.group(3), -100, 100, 0)
 
         if mpr == 'each':
             roll_list, total, maximum, minimum = dnd_roll(params['sides'],

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -42,6 +42,9 @@ class Games(commands.Cog):
         params = {'sides' : 20, # Default parameters
                   'repeat': 1,
                   'mod'   : 0}
+        if arg == 'safe': # nice meme bro
+            await ctx.send('https://i.kym-cdn.com/entries/icons/original/000/022/138/highresrollsafe.jpg') 
+            return
         if arg == 'help' or arg == 'h':
             helpmsg = discord.Embed(title='DnD Dice Roller Help',
                                     description='Usage: `[r]d[s][+m]`\n'

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -34,8 +34,18 @@ class Games(commands.Cog):
     @commands.command()
     async def roll(self, ctx, arg: str = '', mpr: str = ''):
         """
-        Performs a DnD-style diceroll
-        Supports modifiers, multiple rolls, any-sided dice
+        Perform a DnD-style diceroll
+        [r]d[s][+m] ['each']    Rolls an [s]-sided die [r] times, with modifier
+                                [+-m]. If 'each' is specified, applies modifier
+                                to each roll rather than the sum of all rolls.
+                                All parameters are optional.
+                                Defaults to rolling one 20-sided die.
+          Examples:
+           roll             rolls a d20
+           roll d6          roll one 6-sided die
+           roll 3d          rolls 3 20-sided dice
+           roll 5d12-4      rolls 5 12-sided dice, subtracting 4 from the total
+           roll 5d+3 each   rolls 5 20-sided dice, adding 3 to each roll
         """
         roll_pattern = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
         roll_cmd = roll_pattern.match(arg)
@@ -46,25 +56,6 @@ class Games(commands.Cog):
         }
         if arg == 'safe':    # nice meme bro
             await ctx.send('https://i.imgur.com/2icUGpc.png')
-            return
-        if arg == 'help' or arg == 'h':
-            helpmsg = discord.Embed(
-                title='DnD Dice Roller Help',
-                description='Usage: `[r]d[s][+m] [\'each\']`\n'
-                'Rolls an `s`-sided die `r` '
-                'times, with modifier `+-m`.\n'
-                'If `each` is specified, the '
-                'modifier is applied to each roll.\n'
-                'Rolls one 20-sided die by default',
-                colour=0x822AE0)
-            helpmsg.add_field(
-                name='Examples',
-                value='`d6` roll one 6-sided die\n'
-                '`3d` rolls 3 20-sided dice\n'
-                '`5d12-4` rolls 5 12-sided dice, subtracting 4 from the total\n'
-                '`5d+3 each` rolls 5 20-sided dice, adding 3 to each roll',
-                inline=False)
-            await ctx.send(embed=helpmsg)
             return
         elif roll_cmd != None:    # Applying some bounds on parameters
             if roll_cmd.group(1) != '':
@@ -91,7 +82,7 @@ class Games(commands.Cog):
                                           params['mod']) + mod_desc,
             colour=0x822AE0)
         if params[
-                'repeat'] <= 10:    # Anything more and the roll list is too long
+                'repeat'] <= 10:  # Anything more and the roll list is too long
             resultsmsg.add_field(name='Rolls',
                                  value=str(roll_list)[1:-1],
                                  inline=False)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -43,7 +43,7 @@ class Games(commands.Cog):
                   'repeat': 1,
                   'mod'   : 0}
         if arg == 'safe': # nice meme bro
-            await ctx.send('https://i.kym-cdn.com/entries/icons/original/000/022/138/highresrollsafe.jpg') 
+            await ctx.send('https://i.imgur.com/2icUGpc.png') 
             return
         if arg == 'help' or arg == 'h':
             helpmsg = discord.Embed(title='DnD Dice Roller Help',

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -32,7 +32,7 @@ class Games(commands.Cog):
         self.bot = bot
     
     @commands.command()
-    async def roll(self, ctx, arg: str = None):
+    async def roll(self, ctx, arg: str = ''):
         """
         Performs a DnD-style diceroll
         Supports modifiers, multiple rolls, any-sided dice

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -30,74 +30,77 @@ from .utils.dnd_roll import dnd_roll
 class Games(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-    
+
     @commands.command()
-    async def roll(self, ctx, arg: str = '', mpr: str =''):
+    async def roll(self, ctx, arg: str = '', mpr: str = ''):
         """
         Performs a DnD-style diceroll
         Supports modifiers, multiple rolls, any-sided dice
         """
         roll_pattern = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
         roll_cmd = roll_pattern.match(arg)
-        params = {'sides' : 20, # Default parameters
-                  'repeat': 1,
-                  'mod'   : 0}
-        if arg == 'safe': # nice meme bro
-            await ctx.send('https://i.imgur.com/2icUGpc.png') 
+        params = {
+            'sides': 20,    # Default parameters
+            'repeat': 1,
+            'mod': 0
+        }
+        if arg == 'safe':    # nice meme bro
+            await ctx.send('https://i.imgur.com/2icUGpc.png')
             return
         if arg == 'help' or arg == 'h':
-            helpmsg = discord.Embed(title='DnD Dice Roller Help',
-                                    description='Usage: `[r]d[s][+m] [\'each\']`\n'
-                                                'Rolls an `s`-sided die `r` '
-                                                'times, with modifier `+-m`.\n'
-                                                'If `each` is specified, the '
-                                                'modifier is applied to each roll.\n'
-                                                'Rolls one 20-sided die by default',
-                                    colour=0x822AE0)
-            helpmsg.add_field(name='Examples',
-                              value='`d6` roll one 6-sided die\n'
-                                    '`3d` rolls 3 20-sided dice\n'
-                                    '`5d12-4` rolls 5 12-sided dice, subtracting 4 from the total\n'
-                                    '`5d+3 each` rolls 5 20-sided dice, adding 3 to each roll',
-                              inline=False)
+            helpmsg = discord.Embed(
+                title='DnD Dice Roller Help',
+                description='Usage: `[r]d[s][+m] [\'each\']`\n'
+                'Rolls an `s`-sided die `r` '
+                'times, with modifier `+-m`.\n'
+                'If `each` is specified, the '
+                'modifier is applied to each roll.\n'
+                'Rolls one 20-sided die by default',
+                colour=0x822AE0)
+            helpmsg.add_field(
+                name='Examples',
+                value='`d6` roll one 6-sided die\n'
+                '`3d` rolls 3 20-sided dice\n'
+                '`5d12-4` rolls 5 12-sided dice, subtracting 4 from the total\n'
+                '`5d+3 each` rolls 5 20-sided dice, adding 3 to each roll',
+                inline=False)
             await ctx.send(embed=helpmsg)
             return
-        elif roll_cmd != None: # Applying some bounds on parameters
+        elif roll_cmd != None:    # Applying some bounds on parameters
             if roll_cmd.group(1) != '':
-                params['repeat'] = min(max(1,int(roll_cmd.group(1))), 10000)
+                params['repeat'] = min(max(1, int(roll_cmd.group(1))), 10000)
             if roll_cmd.group(2) != '':
-                params['sides'] = min(max(1,int(roll_cmd.group(2))), 100)
+                params['sides'] = min(max(1, int(roll_cmd.group(2))), 100)
             if roll_cmd.group(3) != '':
-                params['mod'] = min(max(-100,int(roll_cmd.group(3))), 100)
-                
+                params['mod'] = min(max(-100, int(roll_cmd.group(3))), 100)
+
         if mpr == 'each':
             roll_list, total, maximum, minimum = dnd_roll(params['sides'],
-                                                      params['repeat'],
-                                                      params['mod'],
-                                                      mpr=True)
+                                                          params['repeat'],
+                                                          params['mod'],
+                                                          mpr=True)
             mod_desc = ' to each roll'
         else:
-            roll_list, total, maximum, minimum = dnd_roll(params['sides'],
-                                                      params['repeat'],
-                                                      params['mod'])
+            roll_list, total, maximum, minimum = dnd_roll(
+                params['sides'], params['repeat'], params['mod'])
             mod_desc = ' to the sum of rolls'
         # Now that we have our rolls, prep the embed:
-        resultsmsg = discord.Embed(description='Rolling {} {}-sided dice'
-                                               ', with a {} modifier'.format(
-                                                    params['repeat'],
-                                                    params['sides'],
-                                                    params['mod'])
-                                               +mod_desc,
-                                   colour=0x822AE0)
-        if params['repeat'] <= 10: # Anything more and the roll list is too long
-            resultsmsg.add_field(name='Rolls', value=str(roll_list)[1:-1], inline=False)
+        resultsmsg = discord.Embed(
+            description='Rolling {} {}-sided dice'
+            ', with a {} modifier'.format(params['repeat'], params['sides'],
+                                          params['mod']) + mod_desc,
+            colour=0x822AE0)
+        if params[
+                'repeat'] <= 10:    # Anything more and the roll list is too long
+            resultsmsg.add_field(name='Rolls',
+                                 value=str(roll_list)[1:-1],
+                                 inline=False)
         if params['repeat'] > 1:
             resultsmsg.add_field(name='Sum', value=total)
             resultsmsg.add_field(name='Minimum', value=minimum)
             resultsmsg.add_field(name='Maximum', value=maximum)
         await ctx.send(embed=resultsmsg)
 
-    
+
 def setup(bot):
     bot.add_cog(Games(bot))
-    

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -28,6 +28,7 @@ from .utils.clamp_default import clamp_default
 
 ROLL_PATTERN = re.compile(r'^(\d*)d(\d*)([+-]?\d*)$')
 
+
 class Games(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -58,27 +59,26 @@ class Games(commands.Cog):
             repeat = clamp_default(roll_cmd.group(1), 1, 10000, 1)
             sides = clamp_default(roll_cmd.group(2), 1, 100, 20)
             mod = clamp_default(roll_cmd.group(3), -100, 100, 0)
-        else: # Necessary for empty roll commands - regex won't even match
+        else:    # Necessary for empty roll commands - regex won't even match
             repeat = 1
             sides = 20
             mod = 0
 
         if mpr == 'each':
             roll_list, total, maximum, minimum = dice_roll(sides,
-                                                          repeat,
-                                                          mod,
-                                                          mpr=True)
+                                                           repeat,
+                                                           mod,
+                                                           mpr=True)
             mod_desc = ' to each roll'
         else:
-            roll_list, total, maximum, minimum = dice_roll(
-                sides, repeat, mod)
+            roll_list, total, maximum, minimum = dice_roll(sides, repeat, mod)
             mod_desc = ' to the sum of rolls'
         # Now that we have our rolls, prep the embed:
         resultsmsg = discord.Embed(
             description='Rolling {} {}-sided dice'
             ', with a {} modifier'.format(repeat, sides, mod) + mod_desc,
             colour=0x822AE0)
-        if repeat <= 10:  # Anything more and the roll list is too long
+        if repeat <= 10:    # Anything more and the roll list is too long
             resultsmsg.add_field(name='Rolls',
                                  value=str(roll_list)[1:-1],
                                  inline=False)

--- a/cogs/utils/clamp_default.py
+++ b/cogs/utils/clamp_default.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) idoneam (2016-2019)
+#
+# This file is part of Canary
+#
+# Canary is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Canary is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Canary. If not, see <https://www.gnu.org/licenses/>.
+
+def clamp_default(val, min_val, max_val, default):
+    """
+    Enforces a minimum and maximum (closed) bound on an integer.
+    Returns a default value if val is not an integer or false-y.
+    """
+    try:
+        if val or isinstance(val, int):
+            return min(max(min_val, int(val)), max_val)
+    except ValueError:
+        pass
+    return default

--- a/cogs/utils/clamp_default.py
+++ b/cogs/utils/clamp_default.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Canary. If not, see <https://www.gnu.org/licenses/>.
 
+
 def clamp_default(val, min_val, max_val, default):
     """
     Enforces a minimum and maximum (closed) bound on an integer.

--- a/cogs/utils/dice_roll.py
+++ b/cogs/utils/dice_roll.py
@@ -25,19 +25,7 @@ def dice_roll(sides=20, n=1, modifier=0, mpr=False):
     Rolls a die with given parameters
     Set mpr to True to mod each roll, otherwise, only the sum is modified
     """
-    roll_list = []
-
-    if mpr == True:
-        roll_mod = modifier
-        total_mod = 0
-    else:
-        roll_mod = 0
-        total_mod = modifier
-
-    for i in range(n):
-        result = randint(1, sides)
-        roll_list.append(result + roll_mod)
-
-    total = sum(roll_list) + total_mod
-
-    return roll_list, total, max(roll_list), min(roll_list)
+    roll_mod = modifier if mpr else 0
+    total_mod = 0 if mpr else modifier
+    roll_list = [randint(1, sides) + roll_mod for _ in range(n)]
+    return roll_list, sum(roll_list)+total_mod, max(roll_list), min(roll_list)

--- a/cogs/utils/dice_roll.py
+++ b/cogs/utils/dice_roll.py
@@ -25,7 +25,19 @@ def dice_roll(sides=20, n=1, modifier=0, mpr=False):
     Rolls a die with given parameters
     Set mpr to True to mod each roll, otherwise, only the sum is modified
     """
-    roll_mod = modifier if mpr else 0
-    total_mod = 0 if mpr else modifier
-    roll_list = [randint(1, sides) + roll_mod for _ in range(n)]
-    return roll_list, sum(roll_list), max(roll_list), min(roll_list)
+    roll_list = []
+
+    if mpr == True:
+        roll_mod = modifier
+        total_mod = 0
+    else:
+        roll_mod = 0
+        total_mod = modifier
+
+    for i in range(n):
+        result = randint(1, sides)
+        roll_list.append(result + roll_mod)
+
+    total = sum(roll_list) + total_mod
+
+    return roll_list, total, max(roll_list), min(roll_list)

--- a/cogs/utils/dice_roll.py
+++ b/cogs/utils/dice_roll.py
@@ -20,7 +20,7 @@
 from random import randint
 
 
-def dnd_roll(sides=20, n=1, modifier=0, mpr=False):
+def dice_roll(sides=20, n=1, modifier=0, mpr=False):
     """
     Rolls a die with given parameters
     Set mpr to True to mod each roll, otherwise, only the sum is modified

--- a/cogs/utils/dice_roll.py
+++ b/cogs/utils/dice_roll.py
@@ -28,4 +28,5 @@ def dice_roll(sides=20, n=1, modifier=0, mpr=False):
     roll_mod = modifier if mpr else 0
     total_mod = 0 if mpr else modifier
     roll_list = [randint(1, sides) + roll_mod for _ in range(n)]
-    return roll_list, sum(roll_list)+total_mod, max(roll_list), min(roll_list)
+    return roll_list, sum(roll_list) + total_mod, max(roll_list), min(
+        roll_list)

--- a/cogs/utils/dice_roll.py
+++ b/cogs/utils/dice_roll.py
@@ -25,19 +25,7 @@ def dice_roll(sides=20, n=1, modifier=0, mpr=False):
     Rolls a die with given parameters
     Set mpr to True to mod each roll, otherwise, only the sum is modified
     """
-    roll_list = []
-
-    if mpr == True:
-        roll_mod = modifier
-        total_mod = 0
-    else:
-        roll_mod = 0
-        total_mod = modifier
-
-    for i in range(n):
-        result = randint(1, sides)
-        roll_list.append(result + roll_mod)
-
-    total = sum(roll_list) + total_mod
-
-    return roll_list, total, max(roll_list), min(roll_list)
+    roll_mod = modifier if mpr else 0
+    total_mod = 0 if mpr else modifier
+    roll_list = [randint(1, sides) + roll_mod for _ in range(n)]
+    return roll_list, sum(roll_list), max(roll_list), min(roll_list)

--- a/cogs/utils/dnd_roll.py
+++ b/cogs/utils/dnd_roll.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) idoneam (2016-2019)
+#
+# This file is part of Canary
+#
+# Canary is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Canary is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Canary. If not, see <https://www.gnu.org/licenses/>.
+
+
+from random import randint
+
+def dnd_roll(sides=20, n=1, modifier=0, mpr=False):
+    """
+    Rolls a die with given parameters
+    Set mpr to True to mod each roll, otherwise, only the sum is modified
+    """
+    roll_list = []
+    
+    if mpr = True:
+        roll_mod = modifier
+        total_mod = 0
+    else:
+        roll_mod = 0
+        total_mod = modifier
+    
+    for i in range(n):
+        result = randint(1,sides)
+        roll_list.append(result + roll_mod)
+    
+    total = sum(roll_list) + total_mod
+    
+    return roll_list, total, max(roll_list), min(roll_list)

--- a/cogs/utils/dnd_roll.py
+++ b/cogs/utils/dnd_roll.py
@@ -17,8 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Canary. If not, see <https://www.gnu.org/licenses/>.
 
-
 from random import randint
+
 
 def dnd_roll(sides=20, n=1, modifier=0, mpr=False):
     """
@@ -26,18 +26,18 @@ def dnd_roll(sides=20, n=1, modifier=0, mpr=False):
     Set mpr to True to mod each roll, otherwise, only the sum is modified
     """
     roll_list = []
-    
+
     if mpr == True:
         roll_mod = modifier
         total_mod = 0
     else:
         roll_mod = 0
         total_mod = modifier
-    
+
     for i in range(n):
-        result = randint(1,sides)
+        result = randint(1, sides)
         roll_list.append(result + roll_mod)
-    
+
     total = sum(roll_list) + total_mod
-    
+
     return roll_list, total, max(roll_list), min(roll_list)

--- a/cogs/utils/dnd_roll.py
+++ b/cogs/utils/dnd_roll.py
@@ -27,7 +27,7 @@ def dnd_roll(sides=20, n=1, modifier=0, mpr=False):
     """
     roll_list = []
     
-    if mpr = True:
+    if mpr == True:
         roll_mod = modifier
         total_mod = 0
     else:


### PR DESCRIPTION
Added the `roll` command, performing DnD style dicerolls. Also added an associated dnd_roll util for potential use in other features.

## Description
Users can roll dice using the XdY format, for example,  `?roll 3d10` rolls 3 ten-sided dice.
Created a `games` cog to hold game-related features and the underlying diceroll function is available in utils.

## Motivation and Context
Resolves #271 

## How Has This Been Tested?
Tried a variety of roll commands to ensure robustness, in most cases, for invalid inputs, it'll just roll a d20.

## Screenshots (if appropriate):
[Examples](https://i.imgur.com/4WozG1Z.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

