### PR TITLE
Issue 276: Fix ?roll - modified single rolls now display sum

### DIFF
--- a/cogs/games.py
+++ b/cogs/games.py
@@ -42,6 +42,10 @@ class Games(commands.Cog):
                                 to each roll rather than the sum of all rolls.
                                 All parameters are optional.
                                 Defaults to rolling one 20-sided die.
+                                
+                                Dice can have 1 to 100 sides
+                                Rolls 1 to 10000 dice at once
+                                Modifier can be any int between -100 and +100
           Examples:
            roll             rolls a d20
            roll d6          rolls one 6-sided die

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -82,10 +82,12 @@ class Games(commands.Cog):
             resultsmsg.add_field(name='Rolls',
                                  value=str(roll_list)[1:-1],
                                  inline=False)
-        if repeat > 1:
+        # Want the modified sum to be shown even for single rolls:
+        if repeat > 1 or mod != 0:
             resultsmsg.add_field(name='Sum', value=total)
-            resultsmsg.add_field(name='Minimum', value=minimum)
-            resultsmsg.add_field(name='Maximum', value=maximum)
+            if repeat > 1:
+                resultsmsg.add_field(name='Minimum', value=minimum)
+                resultsmsg.add_field(name='Maximum', value=maximum)
         await ctx.send(embed=resultsmsg)
 
 


### PR DESCRIPTION
## Description
Changed display conditions for the "Sum" field and added extra details in the `?roll` docstring.

## Motivation and Context
Resolved #276 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

