### PR TITLE
rewrote keydates to work with the new layout

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -318,8 +318,8 @@ class Helpers(commands.Cog):
                     if previous.name == 'p':
                         headers.append(previous.get_text())
                     else:
-                        headers.append("...") # just in case the layout changes again,
-                                              # at least the whole thing won't break
+                        # just in case the layout changes again, at least the whole thing won't break
+                        headers.append("...")
 
             node = node.next_sibling
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
<!--- Describe your changes in detail -->
The `keydates` function was updated to be compatible with the new layout of https://www.mcgill.ca/importantdates/key-dates without exceeding Discord's character limit while still displaying the most useful information. The new function looks specifically for unordered lists, since they contain the actual dates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #300 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The keydates command has been tested in the idoneam server. It has been tested for both fall and winter semesters, the latter achieved by temporarily flipping the condition.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11583993/84210637-3681bb00-aa87-11ea-9396-581f25dd6909.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

