### PR TITLE
Input emoji for editable content. Can return user

### DIFF
--- a/cogs/quotes.py
+++ b/cogs/quotes.py
@@ -281,7 +281,7 @@ class Quotes(commands.Cog):
             except ValueError:
                 return False
 
-        while p.delete:
+        while p.edit_mode:
             await ctx.send(
                 'Delete option selected. Enter a number to specify which '
                 'quote you want to delete, or enter 0 to return.',

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -454,7 +454,7 @@ class Reminder(commands.Cog):
             except ValueError:
                 return False
 
-        while p.delete:
+        while p.edit_mode:
             await ctx.send(
                 'Delete option selected. Enter a number to specify which '
                 'reminder you want to delete, or enter 0 to return.',


### PR DESCRIPTION
**Why this change was necessary**
Before, "editable_content=True" was only used for deletions, and the emoji was always the trash emoji. However, since the function only "gets out" of paginator, it can be useful for other reasons, for example to select an option to edit from a list.
Returning the user who clicked the button can also be useful, for example if they are the only one who will be able to edit.

**What this change does**
It is now possible to select the editable_content_emoji. The trash emoji is still the default one for compatibility with functions already using paginator.
It is now possible to return the user who clicked the button. By default, this isn't activated.
Renamed to "self.delete" to "self.edit_mode". Since this is used outside paginator to see when editable content is selected ("while p.paginator"), this is also changed in every concerned file (quotes.py and reminder.py)

**Any side-effects?**
There could be side-effects if I missed a change from "p.delete" to "p.edit_mode", however I don't think I did.

## How Has This Been Tested?
The quote list and reminder list still works, the delete button still works, etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

