### PR TITLE
Log to webhook 

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -62,8 +62,12 @@ MARTY_RESPONSES = {
 
 @bot.event
 async def on_ready():
-    sys.stdout.write(
-        'Bot is ready, program output will be written to a log file.\n')
+    if bot.config.log_webhook_id and bot.config.log_webhook_token:
+        webhook_string = " and to the log webhook"
+    else:
+        webhook_string = ""
+    sys.stdout.write(f'Bot is ready, program output will be written to a '
+                     f'log file{webhook_string}.\n')
     sys.stdout.flush()
     bot.logger.info('Logged in as {} ({})'.format(bot.user.name, bot.user.id))
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You must set certain values in the `config.ini` file, in particular your Discor
 * `[Logging]`
     * `LogLevel`: [See this for a list of levels](https://docs.python.org/3/library/logging.html#levels). Logs from exceptions and commands like `mix` and `bac` are at the `info` level. Logging messages from the level selected *and* from more severe levels will be sent to your logging file. For example, setting the level to `info` also sends logs from `warning`, `error` and `critical`, but not  from `debug`.
     * `LogFile`: The file where the logging output will be sent (will be created there by the bot if it doesn't exist).
+    * `LogWebhookID`: Optional. If the ID of a webhook is input (and it's token below), logs will also be sent to it. These values are contained in the discord webhook url: discordapp.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
+    * `LogWebhookToken`: Optional. See above. 
 * `[DB]`
     * `Schema`: Location of the Schema file that creates tables in the database (This file already exists so you shouldn't have to change this unless you rename it or change its location).
     * `Path`: Your database file path (will be created there by the bot if it doesn't exist).

--- a/config/config.ini
+++ b/config/config.ini
@@ -36,6 +36,8 @@ Repository = https://github.com/idoneam/Canary.git
 [Logging]
 LogLevel = info
 LogFile = ./canary.log
+LogWebhookID =
+LogWebhookToken =
 
 [DB]
 Schema = ./Martlet.schema

--- a/config/parser.py
+++ b/config/parser.py
@@ -61,6 +61,13 @@ class Parser:
         self.log_file = config['Logging']['LogFile']
         loglevel = config['Logging']['LogLevel'].lower()
         self.log_level = LOG_LEVELS.get(loglevel, logging.WARNING)
+        if config['Logging']['LogWebhookID'] \
+                and config['Logging']['LogWebhookToken']:
+            self.log_webhook_id = int(config['Logging']['LogWebhookID'])
+            self.log_webhook_token = config['Logging']['LogWebhookToken']
+        else:
+            self.log_webhook_id = None
+            self.log_webhook_token = None
 
         # Welcome + Farewell messages
         self.welcome = config['Greetings']['Welcome'].split('\n')


### PR DESCRIPTION
Can now optionally send logs to a discord webhook (on top of sending them to the log file). 

## Why this change was necessary
Makes logs more accessible since we do not need to go look at the log file on the server.

## What this change does
`config.ini` and `parser.py`:
- Add two optional config values: `LogWebhookID` and `LogWebhookToken`. If no values are input, the parser sets the webhook id and token to None.

`bot.py`:
- Create a new custom logging handler that sends a message to the webhook in a code block
- The username of the webhook contains the name of the bot (specified in config.ini), useful in servers with many marty clones like idoneam
- If there is values for `LogWebhookID` and `LogWebhookToken`, adds this handler (on top of the handler that logs to file). Will log only to file otherwise

`main.py`:
- The message sent to console when the bot is started specifies if it only sends to the log file or if it also sends to the webhook

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

