### PR TITLE
Handle MaxConcurrencyReached (send message to server and don't write to log)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -152,6 +152,12 @@ class Canary(commands.Bot):
                 return await ctx.send(
                     'I could not find that member. Please try again.')
 
+        elif isinstance(error, commands.MaxConcurrencyReached):
+            return await ctx.send(f"You cannot use the {ctx.command} command "
+                                  f"more than {error.number} "
+                                  f"time{'s' if error.number != 1 else ''} "
+                                  f"in the same channel!")
+
         self.dev_logger.error('Ignoring exception in command {}:'.format(
             ctx.command))
         self.log_traceback(error)


### PR DESCRIPTION
When MaxConcurrencyReached is raised, send a message to the channel where it was raised saying the command (it mentions it by name) cannot be used more than X time(s) and return without writing to log