### PR TITLE
Timeout now resets on turn. Update help

### DIFF
--- a/cogs/utils/paginator.py
+++ b/cogs/utils/paginator.py
@@ -32,7 +32,8 @@ class Pages:
                  display_option=(1, 0),
                  editable_content=True,
                  editable_content_emoji='🚮',
-                 return_user_on_edit=False):
+                 return_user_on_edit=False,
+                 timeout=300):
         """Creates a paginator.
 
         Parameters
@@ -42,27 +43,52 @@ class Pages:
         current_page: int
             Specify which page to display.
         msg: discord.Message
-            This is helpful for edit function. Specify which message the bot needs to update if an element in the original message is modified.
+            This is helpful for edit function. Specify which message the bot
+            needs to update if an element in the original message is modified.
         item_list: list or dictionary
-            List of items to paginate. Using a dictionary is only useful for embeds option where there is a need for field names and values.
+            List of items to paginate. Using a dictionary is only useful for
+            embeds option where there is a need for field names and values.
         title: str
             Summary of content of the items.
         display_option: tuple
             The first record of the tuple may have these values:
-                0   : Messages will be in code blocks, the number of entries for each page is
-                    defined by user (autosize = False), and item_list will be a list of strings
-                    corresponding to the pages.
-                1   : Code blocks, autosize = True, item_list is a list of strings.
-                2   : Embed, autosize = False, item_list is a dictionary with two keys: names & values
-                    the values of which will be a list. (item_list = {'names': [], 'values': []})
+                0   : Messages will be in code blocks, the number of entries
+                    for each page is defined by user (autosize = False), and
+                    item_list will be a list of strings corresponding to
+                    the pages.
+                1   : Code blocks, autosize = True, item_list is a list
+                    of strings.
+                2   : Embed, autosize = False, item_list is a dictionary
+                    with two keys: names & values, the values of which will
+                    be a list. (item_list = {'names': [], 'values': []})
                 3   : Embed, autosize = False, item_list is a list of strings.
                 4   : Embed, autosize = True, item_list is a dictionary.
                 5   : Embed, autosize = True, item_list is a list of strings.
-            The second record is the user defined size of each page. For autosize = True, this value
-            is ignored.
+            The second record is the user defined size of each page.
+            For autosize = True, this value is ignored.
         editable_content: bool
-            True if the items can be updated by the users (this is like an MVC).
+            True if the items can be updated by the users
+            If this is True, then the editable_content_emoji will be added on
+            the message. When a user clicks it, paginator.edit_mode
+            will be set to True, and the function will return.
+            (If return_user_on_edit is set to True, the user will be returned)
+            A recommended use is then to create a while paginator.edit_mode
+            loop after the await paginator.paginate() call, edit the content
+            there (for example, ask the user which item to delete and delete
+            it), then call paginator.paginate() again in the loop.
             False otherwise.
+        editable_content_emoji: string or discord.Emoji
+            If editable_content is True, this is the emoji that will be
+            added on the message and be used to edit content.
+        return_user_on_edit: bool
+            True if the user that clicked the editable_content_emoji react
+            should be returned when editing.
+            False otherwise.
+        timeout: int
+            The time in seconds before the message gets deleted.
+            The timeout is reset when a user turns pages.
+            It is not recommended to use a value much bigger than the default
+            one.
         """
         self.bot = ctx.bot
         self.guild = ctx.guild
@@ -85,6 +111,7 @@ class Pages:
         self.currentPage = current_page
         self.edit_mode = False
         self.return_user_on_edit = return_user_on_edit
+        self.timeout = timeout
 
     def _organize(self):
         organize_helper_map = {
@@ -192,19 +219,22 @@ class Pages:
             else:
                 if self.displayOption[0] < 2:    # code blocks
                     await self.message.edit(
-                        content=self.pagesToSend[self.currentPage])
+                        content=self.pagesToSend[self.currentPage],
+                        delete_after=self.timeout)
                 else:    # embeds
                     await self.message.edit(
-                        embed=self.pagesToSend[self.currentPage])
+                        embed=self.pagesToSend[self.currentPage],
+                        delete_after=self.timeout)
                 return
         else:
             if self.displayOption[0] < 2:
                 self.message = await self.channel.send(
                     content=self.pagesToSend[self.currentPage],
-                    delete_after=300)
+                    delete_after=self.timeout)
             else:
                 self.message = await self.channel.send(
-                    embed=self.pagesToSend[self.currentPage], delete_after=300)
+                    embed=self.pagesToSend[self.currentPage],
+                    delete_after=self.timeout)
             for (emoji, _) in self.actions:
                 await self.message.add_reaction(emoji)
             return


### PR DESCRIPTION
Timeout can now be changed using the timeout variable. Also, when the pages are "turned", the timeout resets, which makes more sense (users that are currently turning pages shouldn't have the message suddenly deleted while they're using it.) It also makes more sense with custom messages (when a message is inputed in `msg`, it might not necessarily have a `delete_after` value.

Help string was updated with the new variables recently added, and the help for editable_content is now clearer

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

