### PR TITLE
change max concurrency message (it isn't just used for channels)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -151,10 +151,10 @@ class Canary(commands.Bot):
                     'I could not find that member. Please try again.')
 
         elif isinstance(error, commands.MaxConcurrencyReached):
-            return await ctx.send(f"You cannot use the {ctx.command} command "
+            return await ctx.send(f"The {ctx.command} command cannot be used "
                                   f"more than {error.number} "
                                   f"time{'s' if error.number != 1 else ''} "
-                                  f"in the same channel!")
+                                  f"per {error.per.name}")
 
         self.dev_logger.error('Ignoring exception in command {}:'.format(
             ctx.command))


### PR DESCRIPTION
Say "per {error.per.name}" instead of "in the same channel"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

