### PR TITLE
Added userinfo and roles commands

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -662,24 +662,27 @@ class Helpers(commands.Cog):
         if user is None:
             user = ctx.author
         ui_embed = discord.Embed(colour=user.id % 16777215)
+        ui_embed.add_field(name="username",
+                           value=f"{user.name}#{user.discriminator}",
+                           inline=True)
+        ui_embed.add_field(name="display name",
+                           value=user.display_name,
+                           inline=True)
+        ui_embed.add_field(name="id", value=user.id, inline=True)
+        ui_embed.add_field(name="joined server",
+                           value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"),
+                           inline=True)
         ui_embed.add_field(
-            name="username",
-            value=f"{user.name}#{user.discriminator}",
-            inline=True).add_field(
-                name="display name", value=user.display_name, inline=True
-            ).add_field(name="id", value=user.id, inline=True).add_field(
-                name="joined server",
-                value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"),
-                inline=True).add_field(
-                    name="joined discord",
-                    value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"),
-                    inline=True).add_field(
-                        name=f"top role",
-                        value=str(user.top_role),
-                        inline=True).add_field(
-                            name="avatar url",
-                            value=user.avatar_url,
-                            inline=False).set_image(url=user.avatar_url)
+            name="joined discord",
+            value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"),
+            inline=True)
+        ui_embed.add_field(name=f"top role",
+                           value=str(user.top_role),
+                           inline=True)
+        ui_embed.add_field(name="avatar url",
+                           value=user.avatar_url,
+                           inline=False)
+        ui_embed.set_image(url=user.avatar_url)
 
         await ctx.send(embed=ui_embed)
 

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -683,9 +683,13 @@ class Helpers(commands.Cog):
 
         await ctx.send(embed=ui_embed)
 
-    @commands.command()
-    async def roles(self, ctx, user: discord.Member = None):
-        """Show user info"""
+    @commands.command(aliases=["user_roles", "userroles", "useroles"])
+    async def uroles(self, ctx, user: discord.Member = None):
+        """
+        Show user roles
+        Defaults to displaying the roles of the user
+        that called the command, whoever another member's username
+        can be passed as an optional argument to display their roles"""
         if user is None:
             user = ctx.author
         roles_embed = discord.Embed(colour=user.id % 16777215)

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -683,22 +683,6 @@ class Helpers(commands.Cog):
 
         await ctx.send(embed=ui_embed)
 
-    @commands.command(aliases=["user_roles", "userroles", "useroles"])
-    async def uroles(self, ctx, user: discord.Member = None):
-        """
-        Show user roles
-        Defaults to displaying the roles of the user
-        that called the command, whoever another member's username
-        can be passed as an optional argument to display their roles"""
-        if user is None:
-            user = ctx.author
-        roles_embed = discord.Embed(colour=user.id % 16777215)
-        roles_embed.add_field(name=f"roles ({len(user.roles) - 1})",
-                              value="\n".join(
-                                  str(role) for role in user.roles
-                                  if role != ctx.guild.default_role))
-        await ctx.send(embed=roles_embed)
-
 
 def setup(bot):
     bot.add_cog(Helpers(bot))

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -654,28 +654,33 @@ class Helpers(commands.Cog):
 
     @commands.command(aliases=["ui", "av", "avi", "userinfo"])
     async def user_info(self, ctx, user: discord.Member = None):
-        """Show user info"""
+        """
+        Show user info and avi
+        Defaults to displaying the information of the user
+        that called the command, whoever another member's username
+        can be passed as an optional argument to display their info"""
         if user is None:
             user = ctx.author
         ui_embed = discord.Embed(colour=user.id % 16777215)
         ui_embed.add_field(
-            name="name/nick",
-            value=
-            f"name: {user.name}{', nick: '+user.nick if user.nick else ''}\n",
-            inline=False).add_field(
-                name="id", value=user.id, inline=False).add_field(
-                    name="joined server",
-                    value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"),
-                    inline=False).add_field(
-                        name="joined discord",
-                        value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"),
-                        inline=False).add_field(
-                            name=f"top role",
-                            value=str(user.top_role),
-                            inline=False).add_field(
-                                name="avatar url",
-                                value=user.avatar_url,
-                                inline=False).set_image(url=user.avatar_url)
+            name="username",
+            value=f"{user.name}#{user.discriminator}",
+            inline=True).add_field(
+                name="display name", value=user.display_name, inline=True
+            ).add_field(name="id", value=user.id, inline=True).add_field(
+                name="joined server",
+                value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"),
+                inline=True).add_field(
+                    name="joined discord",
+                    value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"),
+                    inline=True).add_field(
+                        name=f"top role",
+                        value=str(user.top_role),
+                        inline=True).add_field(
+                            name="avatar url",
+                            value=user.avatar_url,
+                            inline=False).set_image(url=user.avatar_url)
+
         await ctx.send(embed=ui_embed)
 
     @commands.command()

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -660,21 +660,22 @@ class Helpers(commands.Cog):
         ui_embed = discord.Embed(colour=user.id % 16777215)
         ui_embed.add_field(
             name="name/nick",
-            value=f"name: {user.name}{', nick: '+user.nick if user.nick else ''}"
-        ).add_field(
-            name="id",
-            value=user.id,
-        ).add_field(name="joined server", value=user.joined_at,
+            value=
+            f"name: {user.name}{', nick: '+user.nick if user.nick else ''}\n",
+            inline=False).add_field(
+                name="id", value=user.id, inline=False).add_field(
+                    name="joined server",
+                    value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"),
                     inline=False).add_field(
                         name="joined discord",
-                        value=user.created_at,
-                    ).add_field(
-                        name=f"top role",
-                        value=str(user.top_role),
+                        value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"),
                         inline=False).add_field(
-                            name="avatar url",
-                            value=user.avatar_url,
-                            inline=False).set_image(url=user.avatar_url)
+                            name=f"top role",
+                            value=str(user.top_role),
+                            inline=False).add_field(
+                                name="avatar url",
+                                value=user.avatar_url,
+                                inline=False).set_image(url=user.avatar_url)
         await ctx.send(embed=ui_embed)
 
     @commands.command()

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -652,6 +652,43 @@ class Helpers(commands.Cog):
 
         conn.close()
 
+    @commands.command(aliases=["ui", "av", "avi", "userinfo"])
+    async def user_info(self, ctx, user: discord.Member = None):
+        """Show user info"""
+        if user is None:
+            user = ctx.author
+        ui_embed = discord.Embed(colour=user.id % 16777215)
+        ui_embed.add_field(
+            name="name/nick",
+            value=f"name: {user.name}{', nick: '+user.nick if user.nick else ''}"
+        ).add_field(
+            name="id",
+            value=user.id,
+        ).add_field(name="joined server", value=user.joined_at,
+                    inline=False).add_field(
+                        name="joined discord",
+                        value=user.created_at,
+                    ).add_field(
+                        name=f"top role",
+                        value=str(user.top_role),
+                        inline=False).add_field(
+                            name="avatar url",
+                            value=user.avatar_url,
+                            inline=False).set_image(url=user.avatar_url)
+        await ctx.send(embed=ui_embed)
+
+    @commands.command()
+    async def roles(self, ctx, user: discord.Member = None):
+        """Show user info"""
+        if user is None:
+            user = ctx.author
+        roles_embed = discord.Embed(colour=user.id % 16777215)
+        roles_embed.add_field(name=f"roles ({len(user.roles) - 1})",
+                              value="\n".join(
+                                  str(role) for role in user.roles
+                                  if role != ctx.guild.default_role))
+        await ctx.send(embed=roles_embed)
+
 
 def setup(bot):
     bot.add_cog(Helpers(bot))

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -207,7 +207,8 @@ class Roles(commands.Cog):
 
     @commands.command()
     async def roles(self, ctx, user: discord.Member = None):
-        """Returns list of all roles in server"""
+        """Returns list of all roles in server or
+        the list of a specific user's roles"""
         role_names = [
             role.name
             for role in (ctx.guild.roles if user is None else user.roles)

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -206,13 +206,19 @@ class Roles(commands.Cog):
                                Roles.ALL_CATEGORIES)
 
     @commands.command()
-    async def roles(self, ctx):
+    async def roles(self, ctx, user: discord.Member = None):
         """Returns list of all roles in server"""
-        role_names = [role.name for role in ctx.guild.roles]
+        role_names = [
+            role.name
+            for role in (ctx.guild.roles if user is None else user.roles)
+            if role != ctx.guild.default_role
+        ]
         role_names.reverse()
-        await Roles.paginate_roles(ctx,
-                                   role_names,
-                                   title="All roles in server")
+        await Roles.paginate_roles(
+            ctx,
+            role_names,
+            title=("all roles in server" if user is None else
+                   f"{user.display_name}'s roles") + f" ({len(role_names)})")
 
     @commands.command()
     async def inrole(self, ctx, *, query_role):


### PR DESCRIPTION
Adds `user_info` and changes `roles` commands.

## Description
`user_info` creates an embed containing a user's username, display name (if one exists), user ID, date they joined the server, date they joined discord, their top role and the link to their avatar picture
`roles` command now can be used to get a specific user's roles

## Motivation and Context
reduce reliance on mosebot

## How Has This Been Tested?
tested in idoneam

## Screenshots (if appropriate):
`user_info` example: https://cdn.discordapp.com/attachments/271506037100642314/796155878264668240/Screenshot_20210105_181412.png
new `roles` functionality example: https://cdn.discordapp.com/attachments/271506037100642314/796160132924702720/Screenshot_20210105_183538.png

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

