### PR TITLE
Add option to accept pre-made embed pages

### DIFF
--- a/cogs/utils/paginator.py
+++ b/cogs/utils/paginator.py
@@ -211,8 +211,7 @@ class Pages:
 
     def _organize_embeds_list_embeds(self, pages_to_send):
         page_counter = len(self.itemList)
-        for embed in self.itemList:
-            pages_to_send.append(embed)
+        pages_to_send.extend(self.itemList)
         return pages_to_send, page_counter
 
     async def _show_page(self, page):

--- a/cogs/utils/paginator.py
+++ b/cogs/utils/paginator.py
@@ -64,6 +64,8 @@ class Pages:
                 3   : Embed, autosize = False, item_list is a list of strings.
                 4   : Embed, autosize = True, item_list is a dictionary.
                 5   : Embed, autosize = True, item_list is a list of strings.
+                6   : Embed, autosize = True, item_list is a list of embeds
+                      that will be used as pages
             The second record is the user defined size of each page.
             For autosize = True, this value is ignored.
         editable_content: bool
@@ -121,6 +123,7 @@ class Pages:
             3: self._organize_embeds_list,
             4: self._organize_embeds_autosize_dict,
             5: self._organize_embeds_autosize_list,
+            6: self._organize_embeds_list_embeds,
         }
         pages_to_send = ['empty page']
         self.organize_helper = organize_helper_map[self.displayOption[0]]
@@ -205,6 +208,12 @@ class Pages:
 
     def _organize_embeds_autosize_list(self, pages_to_send):
         pass
+
+    def _organize_embeds_list_embeds(self, pages_to_send):
+        page_counter = len(self.itemList)
+        for embed in self.itemList:
+            pages_to_send.append(embed)
+        return pages_to_send, page_counter
 
     async def _show_page(self, page):
         self.currentPage = max(0, min(page, self.lastPage))


### PR DESCRIPTION
New option for paginator that takes a list of already made pages (embeds)

## Motivation and Context
This option gives more control on the content of the pages

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

