### PR TITLE
[feat][CI] Check Poetry dependencies

### DIFF
--- a/.github/workflows/poetry-dev.yml
+++ b/.github/workflows/poetry-dev.yml
@@ -30,7 +30,7 @@ jobs:
           - 'ubuntu-18.04'
           - 'ubuntu-16.04'
           - 'macos-10.15'
-          - 'macos-11.0'
+          # - 'macos-11.0'
           - 'windows-2019'
           - 'windows-2016'
         python-version:

--- a/.github/workflows/poetry-dev.yml
+++ b/.github/workflows/poetry-dev.yml
@@ -1,4 +1,4 @@
-name: Poetry Development Environment Build
+name: Poetry Development Dependency Installation
 on:
   push:
     branches:
@@ -28,11 +28,9 @@ jobs:
         os:
           - 'ubuntu-20.04'
           - 'ubuntu-18.04'
-          - 'ubuntu-16.04'
           - 'macos-10.15'
           # - 'macos-11.0'
           - 'windows-2019'
-          - 'windows-2016'
         python-version:
           - '3.9'
     steps:

--- a/.github/workflows/poetry-dev.yml
+++ b/.github/workflows/poetry-dev.yml
@@ -1,0 +1,58 @@
+name: Poetry Development Environment Build
+on:
+  push:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/poetry*.yml'
+  pull_request:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/poetry*.yml'
+
+jobs:
+  poetry-dev-build:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os:
+          - 'ubuntu-20.04'
+          - 'ubuntu-18.04'
+          - 'ubuntu-16.04'
+          - 'macos-10.15'
+          - 'macos-11.0'
+          - 'windows-2019'
+          - 'windows-2016'
+        python-version:
+          - '3.9'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install latest version of Poetry
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: Get Poetry version
+        run: poetry --version
+
+      - name: Check pyproject.toml validity
+        run: poetry check --no-interaction
+
+      - name: Install Canary Development Dependencies
+        run: poetry install --no-interaction

--- a/.github/workflows/poetry-prod.yml
+++ b/.github/workflows/poetry-prod.yml
@@ -1,17 +1,8 @@
-name: Poetry Production Environment Build
+name: Poetry Production Dependency Installation
 on:
-  push:
-    branches:
-      - master
-      - dev
-    paths:
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - '.github/workflows/poetry*.yml'
   pull_request:
     branches:
       - master
-      - dev
     paths:
       - 'pyproject.toml'
       - 'poetry.lock'

--- a/.github/workflows/poetry-prod.yml
+++ b/.github/workflows/poetry-prod.yml
@@ -1,0 +1,55 @@
+name: Poetry Production Environment Build
+on:
+  push:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/poetry*.yml'
+  pull_request:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/poetry*.yml'
+
+jobs:
+  poetry-prod-build:
+    env:
+      POETRY_VERSION: "1.1.4"
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os:
+          - 'ubuntu-20.04'
+          - 'ubuntu-18.04'
+        python-version:
+          - '3.9'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -  --version $POETRY_VERSION
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: Get Poetry version
+        run: poetry --version
+
+      - name: Check pyproject.toml validity
+        run: poetry check --no-interaction
+
+      - name: Install Canary Production Dependencies
+        run: poetry install --no-dev --no-interaction


### PR DESCRIPTION
**Why this change was necessary**
We should check the Poetry dependency installation when changes are
made to `pyproject.toml`, `poetry.lock`, or the workflow files themselves.

**What this change does**
Creates workflows that run on PR and Push

**Any side-effects?**
We'll see