### PR TITLE
[docs][README] Update badges

### DIFF
--- a/.github/workflows/poetry-dev.yml
+++ b/.github/workflows/poetry-dev.yml
@@ -1,4 +1,4 @@
-name: Poetry Development Dependency Installation
+name: Dev Dependencies
 on:
   push:
     branches:

--- a/.github/workflows/poetry-prod.yml
+++ b/.github/workflows/poetry-prod.yml
@@ -1,4 +1,4 @@
-name: Poetry Production Dependency Installation
+name: Prod Dependencies
 on:
   pull_request:
     branches:

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Canary is a Python3 bot designed for the McGill University Community Discord Ser
 
 ## Build Statuses
 
-| Master  | [![Build Status](https://github.com/Idoneam/Canary/workflows/YAPF%20Formatting%20Check/badge.svg?branch=master)](https://github.com/Idoneam/Canary/actions?query=branch%3Amaster) |
+| **Master**  | [![Poetry Production Dependency Installation](https://github.com/idoneam/Canary/workflows/Poetry%20Production%20Dependency%20Installation/badge.svg)](https://github.com/Idoneam/Canary/actions?query=branch%3Amaster+workflow%3Aformatting) |
 | ------- | --------------------------------------------------------------------------------------------------------------- |
-| **Dev** | [![Build Status](https://github.com/Idoneam/Canary/workflows/YAPF%20Formatting%20Check/badge.svg?branch=dev)](https://github.com/Idoneam/Canary/actions?query=branch%3Adev)  |
+| **Dev** | [![Poetry Development Dependency Installation](https://github.com/idoneam/Canary/workflows/Poetry%20Development%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Development+Dependency+Installation%22+branch%3Adev)  |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Canary is a Python3 bot designed for the McGill University Community Discord Ser
 
 ## Build Statuses
 
-| **Master**  | [![Prod Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Production%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Production+Dependency+Installation%22+branch%3Amaster) |
+| **Master**  | [![Prod Dependencies](https://github.com/idoneam/Canary/workflows/Prod%20Dependencies/badge.svg?branch=master)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Prod+Dependencies%22+branch%3Amaster) |
 | ------- | --------------------------------------------------------------------------------------------------------------- |
-| **Dev** | [![Dev Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Development%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Development+Dependency+Installation%22+branch%3Adev)  |
+| **Dev** | [![Dev Dependencies](https://github.com/idoneam/Canary/workflows/Dev%20Dependencies/badge.svg?branch=dev)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Dev+Dependencies%22+branch%3Adev)  |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Canary is a Python3 bot designed for the McGill University Community Discord Ser
 
 ## Build Statuses
 
-| **Master**  | [![Poetry Production Dependency Installation](https://github.com/idoneam/Canary/workflows/Poetry%20Production%20Dependency%20Installation/badge.svg)](https://github.com/Idoneam/Canary/actions?query=branch%3Amaster+workflow%3Aformatting) |
+| **Master**  | [![Prod Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Production%20Dependency%20Installation/badge.svg)](https://github.com/Idoneam/Canary/actions?query=branch%3Amaster+workflow%3Aformatting) |
 | ------- | --------------------------------------------------------------------------------------------------------------- |
-| **Dev** | [![Poetry Development Dependency Installation](https://github.com/idoneam/Canary/workflows/Poetry%20Development%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Development+Dependency+Installation%22+branch%3Adev)  |
+| **Dev** | [![Dev Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Development%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Development+Dependency+Installation%22+branch%3Adev)  |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Canary is a Python3 bot designed for the McGill University Community Discord Ser
 
 ## Build Statuses
 
-| **Master**  | [![Prod Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Production%20Dependency%20Installation/badge.svg)](https://github.com/Idoneam/Canary/actions?query=branch%3Amaster+workflow%3Aformatting) |
+| **Master**  | [![Prod Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Production%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Production+Dependency+Installation%22+branch%3Amaster) |
 | ------- | --------------------------------------------------------------------------------------------------------------- |
 | **Dev** | [![Dev Dependencies](https://github.com/idoneam/Canary/workflows/Poetry%20Development%20Dependency%20Installation/badge.svg)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Poetry+Development+Dependency+Installation%22+branch%3Adev)  |
 


### PR DESCRIPTION
**Why this change was necessary**
Dependency installation checks were added in #387. These Actions
should be pointed to by the README badges until we have workflows
actually testing the application build (#268 and others).

**What this change does**
Updates badges to point to the dependency installation workflows.

**Any side-effects?**
None

**Additional context/notes/links**
 - List of open issues mentioning testing: https://github.com/idoneam/Canary/issues?q=is%3Aissue+is%3Aopen+test