### PR TITLE
[feat][CI] Run YAPF workflow only on .py diffs

### DIFF
--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -1,6 +1,9 @@
-name: YAPF Formatting Check
+name: YAPF Check
 
-on: [push]
+on:
+  push:
+    paths:
+      '**.py'
 
 jobs:
   formatting-check:


### PR DESCRIPTION
**Why this change was necessary**
YAPF workflow involves creating a Docker container every time it's
run, then running a YAPF check on the entire project. This workflow
was being triggered on every push, even if Python files are not
touched in a commit.

**What this change does**
 - refines workflow to only run when Python files are touched in a
 pushed commit
 - renames the workflow to yapf.yml, since formatting != linting

**Any side-effects?**
Faster CI checks on PRs that are modifying non-Python files like
`README`, `pyproject.toml`, `poetry.lock`, etc.