### PR TITLE
Added colour info to userinfo

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -656,10 +656,10 @@ class Helpers(commands.Cog):
     @commands.command(aliases=["ui", "av", "avi", "userinfo"])
     async def user_info(self, ctx, user: discord.Member = None):
         """
-        Show user info and avi
-        Defaults to displaying the information of the user
+        Show user info and avatar.
+        Displays the information of the user
         that called the command, or another member's
-        if one is passed as an optional argument"""
+        if one is passed as an optional argument."""
         if user is None:
             user = ctx.author
         ui_embed = discord.Embed(

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -658,28 +658,25 @@ class Helpers(commands.Cog):
         """
         Show user info and avi
         Defaults to displaying the information of the user
-        that called the command, whoever another member's username
-        can be passed as an optional argument to display their info"""
+        that called the command, or another member's
+        if one is passed as an optional argument"""
         if user is None:
             user = ctx.author
-        ui_embed = discord.Embed(colour=user.id % 16777215)
-        ui_embed.add_field(name="username",
-                           value=f"{user.name}#{user.discriminator}",
-                           inline=True)
-        ui_embed.add_field(name="display name",
-                           value=user.display_name,
-                           inline=True)
-        ui_embed.add_field(name="id", value=user.id, inline=True)
+        ui_embed = discord.Embed(
+            colour=(user.id - sum(ord(char) for char in user.name)) % 0xFFFFFF)
+        ui_embed.add_field(name="username", value=str(user))
+        ui_embed.add_field(name="display name", value=user.display_name)
+        ui_embed.add_field(name="id", value=user.id)
         ui_embed.add_field(name="joined server",
-                           value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"),
-                           inline=True)
+                           value=user.joined_at.strftime("%m/%d/%Y, %H:%M:%S"))
         ui_embed.add_field(
             name="joined discord",
-            value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"),
-            inline=True)
-        ui_embed.add_field(name=f"top role",
-                           value=str(user.top_role),
-                           inline=True)
+            value=user.created_at.strftime("%m/%d/%Y, %H:%M:%S"))
+        ui_embed.add_field(
+            name="top role, colour",
+            value=f"`{user.top_role}`, " +
+            (str(user.colour).upper()
+             if user.colour != discord.Colour.default() else "default colour"))
         ui_embed.add_field(name="avatar url",
                            value=user.avatar_url,
                            inline=False)


### PR DESCRIPTION
adds colour hex value to `userinfo` command

## Description
colour hex value is now indicated next to top role in `userinfo` command embed
cleaned up code and docstring in `userinfo` command

## Motivation and Context
neat feature

## How Has This Been Tested?
tested in idoneam discord

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

