### PR TITLE
Fix is_moderator and is_developer checks

### DIFF
--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -30,7 +30,7 @@ def is_moderator():
     def predicate(ctx):
         role = discord.utils.get(ctx.author.roles, name=moderator_role)
         if role is None:
-            raise commands.MissingPermissions(moderator_role)
+            raise commands.MissingPermissions([moderator_role])
         return True
 
     return commands.check(predicate)
@@ -42,7 +42,7 @@ def is_developer():
     def predicate(ctx):
         role = discord.utils.get(ctx.author.roles, name=developer_role)
         if role is None:
-            raise commands.MissingPermissions(moderator_role)
+            raise commands.MissingPermissions([developer_role])
         return True
 
     return commands.check(predicate)


### PR DESCRIPTION
Made this 7 months ago and forgot to make a PR apparently 😄 

-Fixed the lines were the MissingPermission exception is raised: was supposed to take a list of roles as input. 
-is_developer was sending the missing perm for is_moderator