### PR TITLE
Fix is_moderator and is_developer checks

### DIFF
--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -30,7 +30,7 @@ def is_moderator():
     def predicate(ctx):
         role = discord.utils.get(ctx.author.roles, name=moderator_role)
         if role is None:
-            raise commands.MissingPermissions(moderator_role)
+            raise commands.MissingPermissions([moderator_role])
         return True
 
     return commands.check(predicate)
@@ -42,7 +42,7 @@ def is_developer():
     def predicate(ctx):
         role = discord.utils.get(ctx.author.roles, name=developer_role)
         if role is None:
-            raise commands.MissingPermissions(moderator_role)
+            raise commands.MissingPermissions([developer_role])
         return True
 
     return commands.check(predicate)


### PR DESCRIPTION
## Description
-Fixed the lines were the MissingPermission exception is raised: was supposed to take a list of roles as input.
-`is_developer()` was raising MissingPermission with the moderator role instead of developer

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

