### PR TITLE
p-string groups now empty list by default

### DIFF
--- a/cogs/utils/p_strings.py
+++ b/cogs/utils/p_strings.py
@@ -125,7 +125,7 @@ class PString:
                  string,
                  user=None,
                  channel=None,
-                 groups=None,
+                 groups=[],
                  additional_info=None):
         """
         A p-string is composed of a string with placeholders in it,


### PR DESCRIPTION
Minor fix, this should always be a list

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

