### PR TITLE
Fix letter casing issues

### DIFF
--- a/cogs/customreactions.py
+++ b/cogs/customreactions.py
@@ -77,7 +77,7 @@ class CustomReactions(commands.Cog):
         c.execute('SELECT * FROM CustomReactions WHERE Proposal = 0')
         self.reaction_list = c.fetchall()
         prompts = [row[1].lower() for row in self.reaction_list]
-        responses = [row[2].lower() for row in self.reaction_list]
+        responses = [row[2] for row in self.reaction_list]
         anywhere_values = [row[5] for row in self.reaction_list]
         additional_info_list = [(row[4], row[6]) for row in self.reaction_list]
         self.p_strings = PStringEncodings(
@@ -99,7 +99,7 @@ class CustomReactions(commands.Cog):
         if message.author == self.bot.user:
             return
 
-        response = self.p_strings.parser(message.content,
+        response = self.p_strings.parser(message.content.lower(),
                                          user=message.author.mention,
                                          channel=str(message.channel))
         if response:


### PR DESCRIPTION
## Description
the prompts used to make p_strings should indeed be converted to lowercase, but then the messages sent to the parser to compare should also be converted to lowercase first. The responses however should not be lowercase, they should preserve the original casing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

