### PR TITLE
Automatically publish image to GHCR

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Freeze dependencies
+        run: poetry export -f requirements.txt > requirements.txt
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          repository: idoneam/Canary
+          push: ${{ github.event_name != 'pull_request' }}
+          tag_with_ref: true
+          tag_with_sha: true
+          add_git_labels: true
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
This will build and publish a Docker image automatically so it does not have to be built on the server it's deployed on.
<!--- Describe your changes in detail -->

## Motivation and Context
Makes it easier to auto-deploy, move servers, etc – plus offloads work to CI and enables eventual CD

## How Has This Been Tested?
TODO

## Types of changes
N/A (devops)

## Checklist:

TODO: Document

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

