### PR TITLE
fix: givebackroles no longer crashes if a role cannot be given back

### DIFF
--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -595,7 +595,7 @@ class Helpers(commands.Cog):
             conn.close()
 
     @commands.command(aliases=[
-        'previousroles', 'giverolesback', 'rolesback', "givebackroles"
+        "previousroles", "giverolesback", "rolesback", "givebackroles"
     ])
     async def previous_roles(self, ctx, user: discord.Member):
         """Show the list of roles that a user had before leaving, if possible.
@@ -650,8 +650,9 @@ class Helpers(commands.Cog):
                         try:
                             await user.add_roles(
                                 role,
-                                reason="{} used the previous_roles command".
-                                format(ok_user.name))
+                                reason=
+                                f"{ok_user.name} used the previous_roles command"
+                            )
                         except:
                             failed_roles.append(str(role))
                     embed = discord.Embed(

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -653,7 +653,7 @@ class Helpers(commands.Cog):
                                 reason=
                                 f"{ok_user.name} used the previous_roles command"
                             )
-                        except:
+                        except (discord.Forbidden, discord.HTTPException):
                             failed_roles.append(str(role))
                     embed = discord.Embed(
                         title="{}'s previous roles were successfully "

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -594,7 +594,9 @@ class Helpers(commands.Cog):
             conn.commit()
             conn.close()
 
-    @commands.command(aliases=['previousroles', 'giverolesback', 'rolesback'])
+    @commands.command(aliases=[
+        'previousroles', 'giverolesback', 'rolesback', "givebackroles"
+    ])
     async def previous_roles(self, ctx, user: discord.Member):
         """Show the list of roles that a user had before leaving, if possible.
         A moderator can click the OK react on the message to give these roles back
@@ -643,14 +645,22 @@ class Helpers(commands.Cog):
             while p.edit_mode:
                 if discord.utils.get(ok_user.roles,
                                      name=self.bot.config.moderator_role):
-                    await user.add_roles(
-                        *valid_roles,
-                        reason="{} used the previous_roles command".format(
-                            ok_user.name))
+                    failed_roles: list[str] = []
+                    for role in valid_roles:
+                        try:
+                            await user.add_roles(
+                                role,
+                                reason="{} used the previous_roles command".
+                                format(ok_user.name))
+                        except:
+                            failed_roles.append(str(role))
                     embed = discord.Embed(
                         title="{}'s previous roles were successfully "
                         "added back by {}".format(user.display_name,
                                                   ok_user.display_name))
+                    if failed_roles:
+                        embed.add_field(name="roles not given back",
+                                        value=", ".join(failed_roles))
                     await message.edit(embed=embed)
                     await message.clear_reaction("◀")
                     await message.clear_reaction("▶")


### PR DESCRIPTION
fixes `givebackroles` not being able to give back all roles due to crashing halfway through if a user has a nitro booster role

## How Has This Been Tested?
currently being tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

