### PR TITLE
fix: Query metric units for wttr command

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -73,7 +73,7 @@ CourseTemplate = http://www.mcgill.ca/study/2020-2021/courses/{}
 CourseSearchTemplate = http://www.mcgill.ca/study/2020-2021/courses/search?search_api_views_fulltext={}&sort_by=field_subject_code&page={}
 GCWeatherURL = http://weather.gc.ca/city/pages/qc-147_metric_e.html
 GCWeatherAlertURL = https://weather.gc.ca/warnings/report_e.html?qc67
-WttrINTemplate = http://wttr.in/Montreal_2mpq_lang=en.png?_={}
+WttrINTemplate = http://wttr.in/Montreal_2mpq_lang=en.png?_m
 TepidURL = https://tepid.science.mcgill.ca:8443/tepid/screensaver/queues/status
 
 [Subscribers]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
<!--- Describe your changes in detail -->
See title. See https://github.com/chubin/wttr.in#weather-units for API documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
wttr command outputs a PNG with US units instead of metric. Likely caused by hosting from the US, since wttr.in selects units based on IP location of the query, and that this used to not be an issue when we were self-hosted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Verified URL with browser and curl.

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/12765385/130516486-b6502599-6448-4a01-bb0c-b7ce404d88a0.png)

After: 
![image](https://user-images.githubusercontent.com/12765385/130516582-91fabc32-6f29-44cb-9c95-c1a25464d567.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

