### PR TITLE
Tweak Docker build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+config/config.ini
 env/
 tests/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.10-slim-bullseye
 
-# Add testing to get newer SQLite (ugh)
-RUN echo 'deb http://http.us.debian.org/debian/ testing non-free contrib main' >> /etc/apt/sources.list
-
 # Install base apt dependencies
 RUN apt-get update && apt-get install -y git sqlite3
 
@@ -16,13 +13,16 @@ RUN apt-get install -y \
   ffmpeg \
   gcc
 
-# Configure Git settings for update command
-RUN git config --global user.name "Martlet"
-RUN git config --global user.email "idoneam.collective@gmail.com"
-
 # Install requirements with pip to use Docker cache independent of project metadata
-COPY requirements.txt /mnt/
-RUN pip install -r /mnt/requirements.txt
+COPY requirements.txt /
+RUN pip install -r /requirements.txt
 
-WORKDIR /mnt/canary
+# Copy code to the `canary` directory in the image and run the bot from there
+COPY . /canary
+WORKDIR /canary
+
+# Notes:
+#   Users will have to mount their config.ini in by hand
+#   Users should mount a read/writable volume for /canary/data/runtime
+
 CMD ["python3.10", "Main.py"]

--- a/Main.py
+++ b/Main.py
@@ -115,18 +115,6 @@ async def sleep(ctx):
 
 
 @bot.command()
-@is_developer()
-async def update(ctx):
-    """
-    Update the bot by pulling changes from the git repository
-    """
-    bot.dev_logger.info("Update Git repository")
-    shell_output = subprocess.check_output("git pull {}".format(bot.config.repository), shell=True)
-    status_message = shell_output.decode("unicode_escape")
-    await ctx.send("`{}`".format(status_message))
-
-
-@bot.command()
 @is_moderator()
 async def backup(ctx):
     """

--- a/README.md
+++ b/README.md
@@ -166,16 +166,23 @@ docker build -t canary:latest .
 
 #### Running the Container
 
+You will need to download and modify Canary's [config.ini](config/config.ini) to your
+liking, so it can be mounted inside the container.
+
 From within the root of the repository:
 
-```
-docker run -v $(pwd):/mnt/canary canary:latest
+```bash
+# Make a folder (if needed) to store database, pickles, etc.
+mkdir -f runtime-data
+
+# Run the container
+docker run -d \
+  -v $(pwd)/config.ini:/canary/config/config.ini:ro \
+  -v $(pwd)/runtime-data:/canary/data/runtime \
+  canary:latest
 ```
 
 Optionally provide the `-d` flag to run the container in detached state.
-
-Note that the current host directory is mounted into the container, any changes to log files, pickles, configuration are reflected
-across the host and the container.
 
 ## Code Linting
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -65,7 +65,7 @@ ModLogWebhookToken =
 
 [DB]
 Schema = ./Martlet.schema
-Path = ./Martlet.db
+Path = ./data/runtime/Martlet.db
 
 [Greetings]
 Welcome =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
* Makes Docker images more immutable to fit with our new deployment ideas
* Removes update command since it becomes useless/non-functional
<!--- Describe your changes in detail -->

## Motivation and Context
* Docker images should correspond 1:1 with a precise version of Canary, which wasn't the case before
* This should allow automatic container updates (eventually)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

