### PR TITLE
chore(git): Remove references to `master` branch

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -16,8 +16,7 @@ Github provides a user-friendly interface for managing issues for a repository. 
 
 ### Git branches
 
-- **dev**: This is the development branch where all changes are integrated together before being merged into master. You should fork your issue branch from here, and make your PR to merge with this branch. *While technically possible for admins, pushing directly to this branch is strictly forbidden.* Small codestyle and spelling fixes should be committed to the `task/cleanup` branch, and a PR made from there. Once that PR is merged, `task/cleanup` is **NOT** deleted.
-- **master**: This is the deployment branch, direct push are blocked for both admin and regular members. Ideally, code contained in this branch should be the least error-prone.
+- **dev**: This is the development branch where all changes are integrated together before being release via tags. You should fork your issue branch from here, and make your PR to merge with this branch. *While technically possible for admins, pushing directly to this branch is strictly forbidden.* Small codestyle and spelling fixes should be committed to the `task/cleanup` branch, and a PR made from there. Once that PR is merged, `task/cleanup` is **NOT** deleted.
 - **Feature/Issue branches**: Anytime you want to work on resolving an issue or implementing a new feature, branch off of the `dev` branch into one of these branches. Name the branch `issue-x` where `x` is the issue number with the issue you are trying to resolve/feature you are trying to implement. You can be more descriptive so other people know what exactly you are working on. Example: `issue-42` or `issue-30/paginator` are both acceptable.
 
 ### Testing

--- a/.github/workflows/poetry-dev.yml
+++ b/.github/workflows/poetry-dev.yml
@@ -2,7 +2,6 @@ name: Dev Dependencies
 on:
   push:
     branches:
-      - master
       - dev
     paths:
       - 'pyproject.toml'
@@ -10,7 +9,6 @@ on:
       - '.github/workflows/poetry*.yml'
   pull_request:
     branches:
-      - master
       - dev
     paths:
       - 'pyproject.toml'

--- a/.github/workflows/poetry-prod.yml
+++ b/.github/workflows/poetry-prod.yml
@@ -2,7 +2,7 @@ name: Prod Dependencies
 on:
   pull_request:
     branches:
-      - master
+      - 'dev'
     paths:
       - 'pyproject.toml'
       - 'poetry.lock'

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Canary is a Python3 bot designed for the McGill University Community Discord Ser
 
 ## Build Statuses
 
-| **Master**  | [![Prod Dependencies](https://github.com/idoneam/Canary/workflows/Prod%20Dependencies/badge.svg?branch=master)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Prod+Dependencies%22+branch%3Amaster) |
-| ------- | --------------------------------------------------------------------------------------------------------------- |
-| **Dev** | [![Dev Dependencies](https://github.com/idoneam/Canary/workflows/Dev%20Dependencies/badge.svg?branch=dev)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Dev+Dependencies%22+branch%3Adev)  |
+[![Dev Dependencies](https://github.com/idoneam/Canary/workflows/Dev%20Dependencies/badge.svg?branch=dev)](https://github.com/idoneam/Canary/actions?query=workflow%3A%22Dev+Dependencies%22+branch%3Adev)
 
 ## Installation
 
@@ -193,4 +191,4 @@ poetry run black --diff . -t py310 --fast
 
 ## Contributions
 
-Contributions are welcome, feel free to fork our repository and open a pull request or open an issue. Please [review our contribution guidelines](https://github.com/idoneam/Canary/blob/master/.github/contributing.md) before contributing.
+Contributions are welcome, feel free to fork our repository and open a pull request or open an issue. Please [review our contribution guidelines](https://github.com/idoneam/Canary/blob/dev/.github/contributing.md) before contributing.


### PR DESCRIPTION
We deleted the `master` branch because it was not needed. Our releases
will be tags on `dev` now, and `dev` will remain the trunk branch.

-------