### PR TITLE
refactor: assign dependabot PRs to team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,7 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
-  reviewers:
-  - davidlougheed
-  - le-potate
-  - namemcguffin
   assignees:
-  - davidlougheed
-  - le-potate
-  - namemcguffin
+  - idoneam/dependabot-assignees
   labels:
   - dependencies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title -->

## Description
Instead of hardcoding @davidlougheed @le-potate and @namemcguffin as the assignees we just make the bot assign the team created for this

This also removes them as reviewers since it's really more of an assignment anyway

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

