### PR TITLE
Spoilerize

### DIFF
--- a/Martlet.schema
+++ b/Martlet.schema
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) idoneam (2016-2019)
+ * Copyright (C) idoneam (2016-2022)
  *
  * This file is part of Canary
  *
@@ -96,3 +96,7 @@ CREATE TABLE IF NOT EXISTS `BannerSubmissions` (
 	`ConvertedMessageID`  INTEGER
 );
 
+CREATE TABLE IF NOT EXISTS `SpoilerizedMessages` (
+	`MessageID`           INTEGER UNIQUE,
+	`UserID`              INTEGER
+);

--- a/cogs/helpers.py
+++ b/cogs/helpers.py
@@ -115,7 +115,7 @@ class Helpers(commands.Cog):
         """
 
         wind_speed_mps = ws_kph * 1000 / 3600
-        wind_chill = 13.12 + 0.6215 * temp - 11.37 * ws_kph ** 0.16 + 0.3965 * temp * ws_kph ** 0.16
+        wind_chill = 13.12 + 0.6215 * temp - 11.37 * ws_kph**0.16 + 0.3965 * temp * ws_kph**0.16
         vapour_pressure = humidity / 100 * 6.105 * math.exp((17.27 * temp) / (237.7 + temp))
         apparent_temperature = temp + 0.33 * vapour_pressure - 0.7 * wind_speed_mps - 4.00
         feels_like = temp

--- a/cogs/utils/arg_converter.py
+++ b/cogs/utils/arg_converter.py
@@ -1,4 +1,4 @@
-# Copyright (C) idoneam (2016-2021)
+# Copyright (C) idoneam (2016-2022)
 #
 # This file is part of Canary
 #
@@ -144,3 +144,22 @@ class ArgConverter:
             else:
                 converted_arguments_dict[key] = self._converters_dict[key][1]
         return converted_arguments_dict
+
+
+# Default converters
+class IntConverter(commands.Converter):
+    @staticmethod
+    async def convert(ctx, argument):
+        try:
+            return int(argument)
+        except ValueError:
+            raise commands.BadArgument("Expected integer as input")
+
+
+class StrConverter(commands.Converter):
+    @staticmethod
+    async def convert(ctx, argument):
+        try:
+            return str(argument)
+        except ValueError:
+            raise commands.BadArgument("Expected string as input")


### PR DESCRIPTION
New feature that lets mods repost messages as spoilers. The messages appear as though they have been sent by the user itself. Users can also use this feature for themselves, although it is not that useful in that case.

This also has an atomic commit of arg_converter which now has two default converters.

## How Has This Been Tested?
Light testing to ensure the main functions work and this doesn't break the bot completely. We should go ahead and merge this ASAP as this is needed quickly, but we should keep in mind that we may need to work on this again in the near future.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

